### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ usage: ./scripts/create_sibling.sh [OPTIONS]
 
   Options:
     -n <name> # Name of the pwnagotchi (default: pwnagotchi)
+    -i <file> # Provide the path of an already downloaded raspbian image
     -o <file> # Name of the img-file (default: pwnagotchi.img)
     -s <size> # Size which should be added to second partition (in Gigabyte) (default: 4)
     -p        # Only run provisioning (assumes the image is already mounted)
@@ -80,6 +81,8 @@ The UI is available either via display if installed, or via http://10.0.0.2:8080
 - `/var/log/pwnagotchi.log` is your friend.
 - if connected to a laptop via usb data port, with internet connectivity shared, magic things will happen.
 - checkout the `ui.video` section of the `config.yml` - if you don't want to use a display, you can connect to it with the browser and a cable.
+- If you get `[FAILED] Failed to start Remount Root and Kernel File Systems.` while booting pwnagotchi, make sure 
+the `PARTUUID`s for `rootfs` and `boot` partitions are the same in `/etc/fstab`. Use `sudo blkid` to find those values when you are using `create_sibling.sh`.
 
 ## License
 


### PR DESCRIPTION
* Added the -i option in Usage section for create_sibling.sh
* Added troubleshooting for a special case when creating a sibling, incorrect PARTUUIDs are saved in /etc/fstab, resulting in mount error while booting.