### PR TITLE
Update create_sibling.sh

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -168,6 +168,7 @@ function provision_raspbian() {
   cd caplets
   make install
   rm -rf /tmp/caplets
+  cd /root # fixes getcwd error that was bugging me
 
   # Re4son-Kernel
   echo "deb http://http.re4son-kernel.com/re4son/ kali-pi main" > /etc/apt/sources.list.d/re4son.list


### PR DESCRIPTION
Fixed a getcwd() error. TL;DR we were deleting a directory we were in and never moving out of it, which lead to the output being flooded with getcwd() errors.

Edit: doing cd /root because it makes the most sense (and got rid of the error...), could just cd to / or whatever 