### PR TITLE
adding resolv.conf for DNS resolution in chroot

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -100,6 +100,7 @@ function setup_raspbian(){
   mount --bind /proc "${MNT_DIR}/proc/"
   mount --bind /dev/pts "${MNT_DIR}/dev/pts"
   cp /usr/bin/qemu-arm-static "${MNT_DIR}/usr/bin"
+  cp /etc/resolv.conf "${MNT_DIR}/etc/resolv.conf"
 }
 
 function provision_raspbian() {


### PR DESCRIPTION
Had to add resolv.conf to get DNS resolution when working on this last night. Within chroot, apt / pip wouldn't update, fixed by adding this