### PR TITLE
Support for InkyPHAT displays from pimoroni using the inky library

### DIFF
--- a/sdcard/rootfs/root/pwnagotchi/config.yml
+++ b/sdcard/rootfs/root/pwnagotchi/config.yml
@@ -15,7 +15,7 @@ main:
     # if not null, filter access points by this regular expression
     filter: null
     # cryptographic key for identity
-    pubkey: /etc/ssh/ssh_host_rsa_key.pub  
+    pubkey: /etc/ssh/ssh_host_rsa_key.pub
 
 ai:
     # if false, only the default 'personality' will be used
@@ -34,7 +34,7 @@ ai:
         vf_coef: 0.25
         # entropy coefficient for the loss calculation
         ent_coef: 0.01
-        # maximum value for the gradient clipping 
+        # maximum value for the gradient clipping
         max_grad_norm: 0.5
         # the learning rate
         learning_rate: 0.0010
@@ -81,7 +81,7 @@ personality:
     # number of active epochs that triggers the excited state
     excited_num_epochs: 10
     # number of inactive epochs that triggers the bored state
-    bored_num_epochs: 15 
+    bored_num_epochs: 15
     # number of inactive epochs that triggers the sad state
     sad_num_epochs: 25
 
@@ -90,6 +90,10 @@ ui:
     # ePaper display can update every 3 secs anyway
     fps: 0.3
     display:
+        # Possible options inkyphat/waveshare
+        type: 'inkyphat'
+        # Possible options red/yellow/black (black used for monocromatic displays)
+        display_color: 'red'
         enabled: true
         rotation: 180
         video:
@@ -113,7 +117,7 @@ bettercap:
     port: 8081
     username: user
     password: pass
-    # folder where bettercap stores the WPA handshakes, given that 
+    # folder where bettercap stores the WPA handshakes, given that
     # wifi.handshakes.aggregate will be set to false and individual
     # pcap files will be created in order to minimize the chances
     # of a single pcap file to get corrupted

--- a/sdcard/rootfs/root/pwnagotchi/config.yml
+++ b/sdcard/rootfs/root/pwnagotchi/config.yml
@@ -11,9 +11,7 @@ main:
     # if true, will not restart the wifi module
     no_restart: false
     # access points to ignore
-    whitelist:
-        - Casa-2.4
-        - LOTS_OF_MALWARE
+    whitelist: []
     # if not null, filter access points by this regular expression
     filter: null
     # cryptographic key for identity

--- a/sdcard/rootfs/root/pwnagotchi/scripts/main.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/main.py
@@ -62,7 +62,7 @@ if args.do_manual:
 
             core.log("detected a new session and internet connectivity!")
 
-            picture = '/tmp/pwnagotchi.png'
+            picture = '/dev/shm/pwnagotchi.png'
 
             display.update()
             display.image().save(picture, 'png')
@@ -121,9 +121,9 @@ while True:
         # An interesting effect of this:
         #
         # From Pwnagotchi's perspective, the more new access points
-        # and / or client stations nearby, the longer one epoch of 
+        # and / or client stations nearby, the longer one epoch of
         # its relative time will take ... basically, in Pwnagotchi's universe,
-        # WiFi electromagnetic fields affect time like gravitational fields 
+        # WiFi electromagnetic fields affect time like gravitational fields
         # affect ours ... neat ^_^
         agent.next_epoch()
     except Exception as e:

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/log.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/log.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import time
 import re
+import os
 from datetime import datetime
 
 from pwnagotchi.mesh.peer import Peer
@@ -129,7 +130,7 @@ class SessionParser(object):
             self.duration_human.append('%d seconds' % secs)
 
         self.duration_human = ', '.join(self.duration_human)
-        self.avg_reward /= self.epochs
+        self.avg_reward /= (self.epochs if self.epochs else 1)
 
     def __init__(self, path='/var/log/pwnagotchi.log'):
         self.path = path
@@ -147,15 +148,17 @@ class SessionParser(object):
             'detected unit (.+)@(.+) \(v.+\) on channel \d+ \(([\d\-]+) dBm\) \[sid:(.+) pwnd_tot:(\d+) uptime:(\d+)\]')
 
         lines = []
-        with FileReadBackwards(self.path, encoding="utf-8") as fp:
-            for line in fp:
-                line = line.strip()
-                if line != "" and line[0] != '[':
-                    continue
-                lines.append(line)
-                if SessionParser.START_TOKEN in line:
-                    break
-        lines.reverse()
+
+        if os.path.exists(self.path):
+            with FileReadBackwards(self.path, encoding="utf-8") as fp:
+                for line in fp:
+                    line = line.strip()
+                    if line != "" and line[0] != '[':
+                        continue
+                    lines.append(line)
+                    if SessionParser.START_TOKEN in line:
+                        break
+            lines.reverse()
 
         self.last_session = lines
         self.last_session_id = hashlib.md5(lines[0].encode()).hexdigest()

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/fonts.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/fonts.py
@@ -5,4 +5,4 @@ PATH = '/usr/share/fonts/truetype/dejavu/DejaVuSansMono'
 Bold = ImageFont.truetype("%s-Bold.ttf" % PATH, 10)
 BoldSmall = ImageFont.truetype("%s-Bold.ttf" % PATH, 9)
 Medium = ImageFont.truetype("%s.ttf" % PATH, 10)
-Huge = ImageFont.truetype("%s-Bold.ttf" % PATH, 35)
+Huge = ImageFont.truetype("%s-Bold.ttf" % PATH, 30)

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/fonts.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/fonts.py
@@ -3,6 +3,6 @@ from PIL import ImageFont
 PATH = '/usr/share/fonts/truetype/dejavu/DejaVuSansMono'
 
 Bold = ImageFont.truetype("%s-Bold.ttf" % PATH, 10)
-BoldSmall = ImageFont.truetype("%s-Bold.ttf" % PATH, 9)
+BoldSmall = ImageFont.truetype("%s-Bold.ttf" % PATH, 8)
 Medium = ImageFont.truetype("%s.ttf" % PATH, 10)
-Huge = ImageFont.truetype("%s-Bold.ttf" % PATH, 30)
+Huge = ImageFont.truetype("%s-Bold.ttf" % PATH, 25)

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
@@ -50,9 +50,9 @@ class View(object):
             'friend_face': Text(value=None, position=(0, 90), font=fonts.Bold, color=BLACK),
             'friend_name': Text(value=None, position=(40, 93), font=fonts.BoldSmall, color=BLACK),
 
-            'name': Text(value='%s>' % 'pwnagotchi', position=(int(self._width / 2), int(self._height * .15)), color=BLACK, font=fonts.Bold),
+            'name': Text(value='%s>' % 'pwnagotchi', position=(int(self._width / 2) - 5, int(self._height * .15)), color=BLACK, font=fonts.Bold),
             # 'face2':   Bitmap( '/root/pwnagotchi/data/images/face_happy.bmp', (0, 20)),
-            'status': Text(value=voice.default(), position=(int(self._width /2), int(self._height * .30)), color=BLACK, font=fonts.Medium),
+            'status': Text(value=voice.default(), position=(int(self._width /2) - 5, int(self._height * .30)), color=BLACK, font=fonts.Medium),
 
             'shakes': LabeledValue(label='PWND ', value='0 (00)', color=BLACK, position=(0, self._height - int(self._height * .12) + 1), label_font=fonts.Bold,
                                    text_font=fonts.Medium),

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
@@ -14,9 +14,6 @@ from pwnagotchi.ui.state import State
 
 WHITE = 0xff
 BLACK = 0x00
-WIDTH = 122
-HEIGHT = 250
-
 
 class View(object):
     def __init__(self, config, state={}):
@@ -24,6 +21,14 @@ class View(object):
         self._config = config
         self._canvas = None
         self._lock = Lock()
+
+        if config['ui']['display']['type'] == 'inkyphat':
+            self._width = 212
+            self._height = 104
+        else:
+            self._width = 250
+            self.heigth = 122
+
         self._state = State(state={
             'channel': LabeledValue(color=BLACK, label='CH', value='00', position=(0, 0), label_font=fonts.Bold,
                                     text_font=fonts.Medium),
@@ -31,27 +36,27 @@ class View(object):
                                 text_font=fonts.Medium),
             #'epoch': LabeledValue(color=BLACK, label='E', value='0000', position=(145, 0), label_font=fonts.Bold,
             #                      text_font=fonts.Medium),
-            'uptime': LabeledValue(color=BLACK, label='UP', value='00:00:00', position=(185, 0), label_font=fonts.Bold,
+            'uptime': LabeledValue(color=BLACK, label='UP', value='00:00:00', position=(self._width - 65, 0), label_font=fonts.Bold,
                                    text_font=fonts.Medium),
 
             # 'square':  Rect([1, 11, 124, 111]),
-            'line1': Line([0, 13, 250, 13], color=BLACK),
-            'line2': Line([0, 109, 250, 109], color=BLACK),
+            'line1': Line([0, int(self._height * .12), self._width, int(self._height * .12)], color=BLACK),
+            'line2': Line([0, self._height - int(self._height * .12), self._width, self._height - int(self._height * .12)], color=BLACK),
 
             # 'histogram': Histogram([4, 94], color = BLACK),
 
-            'face': Text(value=faces.SLEEP, position=(0, 40), color=BLACK, font=fonts.Huge),
+            'face': Text(value=faces.SLEEP, position=(0, int(self._height / 4)), color=BLACK, font=fonts.Huge),
 
             'friend_face': Text(value=None, position=(0, 90), font=fonts.Bold, color=BLACK),
             'friend_name': Text(value=None, position=(40, 93), font=fonts.BoldSmall, color=BLACK),
 
-            'name': Text(value='%s>' % 'pwnagotchi', position=(125, 20), color=BLACK, font=fonts.Bold),
+            'name': Text(value='%s>' % 'pwnagotchi', position=(int(self._width / 2), int(self._height * .15)), color=BLACK, font=fonts.Bold),
             # 'face2':   Bitmap( '/root/pwnagotchi/data/images/face_happy.bmp', (0, 20)),
-            'status': Text(value=voice.default(), position=(125, 35), color=BLACK, font=fonts.Medium),
+            'status': Text(value=voice.default(), position=(int(self._width /2), int(self._height * .30)), color=BLACK, font=fonts.Medium),
 
-            'shakes': LabeledValue(label='PWND ', value='0 (00)', color=BLACK, position=(0, 110), label_font=fonts.Bold,
+            'shakes': LabeledValue(label='PWND ', value='0 (00)', color=BLACK, position=(0, self._height - int(self._height * .12) + 1), label_font=fonts.Bold,
                                    text_font=fonts.Medium),
-            'mode': Text(value='AUTO', position=(225, 110), font=fonts.Bold, color=BLACK),
+            'mode': Text(value='AUTO', position=(self._width - 25, self._height - int(self._height * .12) + 1), font=fonts.Bold, color=BLACK),
         })
 
         for key, value in state.items():
@@ -163,8 +168,8 @@ class View(object):
 
         for step in range(0, 10):
             # if we weren't in a normal state before goin
-            # to sleep, keep that face and status on for 
-            # a while, otherwise the sleep animation will 
+            # to sleep, keep that face and status on for
+            # a while, otherwise the sleep animation will
             # always override any minor state change before it
             if was_normal or step > 5:
                 if sleeping:
@@ -293,7 +298,7 @@ class View(object):
               1    0.000    0.000    0.000    0.000 ImageMode.py:20(ModeDescriptor)
         """
         with self._lock:
-            self._canvas = Image.new('1', (HEIGHT, WIDTH), WHITE)
+            self._canvas = Image.new('1', (self._width, self._height), WHITE)
             drawer = ImageDraw.Draw(self._canvas)
 
             for key, lv in self._state.items():

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
@@ -50,9 +50,9 @@ class View(object):
             'friend_face': Text(value=None, position=(0, 90), font=fonts.Bold, color=BLACK),
             'friend_name': Text(value=None, position=(40, 93), font=fonts.BoldSmall, color=BLACK),
 
-            'name': Text(value='%s>' % 'pwnagotchi', position=(int(self._width / 2) - 5, int(self._height * .15)), color=BLACK, font=fonts.Bold),
+            'name': Text(value='%s>' % 'pwnagotchi', position=(int(self._width / 2) - 15, int(self._height * .15)), color=BLACK, font=fonts.Bold),
             # 'face2':   Bitmap( '/root/pwnagotchi/data/images/face_happy.bmp', (0, 20)),
-            'status': Text(value=voice.default(), position=(int(self._width /2) - 5, int(self._height * .30)), color=BLACK, font=fonts.Medium),
+            'status': Text(value=voice.default(), position=(int(self._width /2) - 15, int(self._height * .30)), color=BLACK, font=fonts.Medium),
 
             'shakes': LabeledValue(label='PWND ', value='0 (00)', color=BLACK, position=(0, self._height - int(self._height * .12) + 1), label_font=fonts.Bold,
                                    text_font=fonts.Medium),

--- a/sdcard/rootfs/root/pwnagotchi/scripts/requirements.txt
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/requirements.txt
@@ -8,3 +8,4 @@ tensorflow
 tweepy
 file_read_backwards
 numpy
+inky


### PR DESCRIPTION
This PR adds the following changes:
- Support for InkyPHAT displays
- Configuration options to configure said displays under the 'ui' branch of the config.yml file
- Adds initial support for dynamic elements positioning on the screen (untested in other screens, also the element of 2 pwnagotchis communicating was not adjusted as I'm waiting for my second pi to test it)
- The face font size was changed to allow it to fit on smaller screens, functionality to dynamically change yet to come
- Minor change to move the temporary twitter image to /dev/shm to avoid unnecessary SD card writes
