### PR TITLE
services cleanup. powersave features and shellcheck fixes

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -195,6 +195,9 @@ function provision_raspbian() {
   # slows down boot
   systemctl disable apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service
 
+  # unecessary services
+  systemctl disable triggerhappy bluetooth wpa_supplicant
+
 EOF
   sed -i'' 's/^#//g' etc/ld.so.preload
   cd "${REPO_DIR}"
@@ -213,7 +216,7 @@ usage: $0 [OPTIONS]
     -i <file>    # Provide the path of an already downloaded raspbian image
     -o <file>    # Name of the img-file (default: pwnagotchi.img)
     -s <size>    # Size which should be added to second partition (in Gigabyte) (default: 4)
-    -v <version> # Version of raspbian (Supported: $SUPPORTED_RASPBIAN_VERSIONS; default: latest)
+    -v <version> # Version of raspbian (Supported: ${SUPPORTED_RASPBIAN_VERSIONS[*]}; default: latest)
     -p           # Only run provisioning (assumes the image is already mounted)
     -d           # Only run dependencies checks
     -h           # Show this help

--- a/scripts/linux_connection_share.sh
+++ b/scripts/linux_connection_share.sh
@@ -7,12 +7,12 @@ USB_IFACE_NET=10.0.0.0/24
 # host interface to use for upstream connection
 UPSTREAM_IFACE=${2:-enxe4b97aa99867}
 
-ip addr add $USB_IFACE_IP/24 dev $USB_IFACE
-ip link set $USB_IFACE up
+ip addr add "$USB_IFACE_IP/24" dev "$USB_IFACE"
+ip link set "$USB_IFACE" up
 
-iptables -A FORWARD -o $UPSTREAM_IFACE -i $USB_IFACE -s $USB_IFACE_NET -m conntrack --ctstate NEW -j ACCEPT
+iptables -A FORWARD -o "$UPSTREAM_IFACE" -i "$USB_IFACE" -s "$USB_IFACE_NET" -m conntrack --ctstate NEW -j ACCEPT
 iptables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -t nat -F POSTROUTING
-iptables -t nat -A POSTROUTING -o $UPSTREAM_IFACE -j MASQUERADE
+iptables -t nat -A POSTROUTING -o "$UPSTREAM_IFACE" -j MASQUERADE
 
 echo 1 > /proc/sys/net/ipv4/ip_forward

--- a/sdcard/boot/config.txt
+++ b/sdcard/boot/config.txt
@@ -1195,10 +1195,6 @@ dtoverlay=dwc2
 dtparam=spi=on
 dtoverlay=spi1-3cs
 
-# Powersave options
-# Disable power LED ~30ma
-dtparam=act_led_trigger=none
-dtparam=act_led_activelow=on
 # Disable bluetooth
 dtoverlay=pi3-disable-bt
 # Disable audio

--- a/sdcard/boot/config.txt
+++ b/sdcard/boot/config.txt
@@ -1195,3 +1195,12 @@ dtoverlay=dwc2
 dtparam=spi=on
 dtoverlay=spi1-3cs
 
+# Powersave options
+# Disable power LED ~30ma
+dtparam=act_led_trigger=none
+dtparam=act_led_activelow=on
+# Disable bluetooth
+dtoverlay=pi3-disable-bt
+# Disable audio
+dtparam=audio=off
+

--- a/sdcard/rootfs/etc/rc.local
+++ b/sdcard/rootfs/etc/rc.local
@@ -10,5 +10,7 @@
 # bits.
 #
 # By default this script does nothing.
+# Powersave (Disable HDMI) ~30ma
+/opt/vc/bin/tvservice -o
 /root/pwnagotchi/scripts/startup.sh &
 exit 0

--- a/sdcard/rootfs/root/pwnagotchi/data/screenrc.auto
+++ b/sdcard/rootfs/root/pwnagotchi/data/screenrc.auto
@@ -5,6 +5,7 @@ defscrollback 1024
 startup_message off
 altscreen on
 autodetach on
+zombie kr
 
 activity        "activity in %n (%t)"
 bell_msg        "bell in %n (%t)"

--- a/sdcard/rootfs/root/pwnagotchi/data/screenrc.manual
+++ b/sdcard/rootfs/root/pwnagotchi/data/screenrc.manual
@@ -5,6 +5,7 @@ defscrollback 1024
 startup_message off
 altscreen on
 autodetach on
+zombie kr
 
 activity        "activity in %n (%t)"
 bell_msg        "bell in %n (%t)"

--- a/sdcard/rootfs/root/pwnagotchi/scripts/blink.sh
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/blink.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for i in `seq 1 $1`;
+for i in $(seq 1 "$1");
 do
 	echo 0 >/sys/class/leds/led0/brightness
 	sleep 0.3
@@ -10,3 +10,8 @@ done
 
 echo 0 >/sys/class/leds/led0/brightness
 sleep 0.3
+
+# Powersave options
+# Disable power LED ~30ma
+echo none >/sys/class/leds/led0/trigger
+echo 1 >/sys/class/leds/led0/brightness


### PR DESCRIPTION
This PR disable services that are not necessary at the moment, if they are in the future we can re-enable them.

This will allow us to speed up the boot process, save memory and also battery usage from users running portable.

Services disabled:
- triggerhappy
- bluetooth

Powersave changes:
- Disable power LED (According to some blog posts it saves ~30ma)
- Disable bluetooth
- Disable audio
- Disable HDMI (Also saves ~30ma)

Also some minor shellcheck fixes.

If we start using bluetooth in the future, we need to change config.txt and re-enable the bluetooth service.