### PR TITLE
Changed hardcoded paths

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # based on: https://wiki.debian.org/RaspberryPi/qemu-user-static
 ## and https://z4ziggy.wordpress.com/2015/05/04/from-bochs-to-chroot/
 

--- a/scripts/linux_connection_share.sh
+++ b/scripts/linux_connection_share.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # name of the ethernet gadget interface on the host
 USB_IFACE=${1:-enp0s20f0u1}

--- a/sdcard/rootfs/root/pwnagotchi/scripts/blink.sh
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/blink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for i in `seq 1 $1`;
 do

--- a/sdcard/rootfs/root/pwnagotchi/scripts/startup.sh
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # blink 10 times to signal ready state
 /root/pwnagotchi/scripts/blink.sh 10 &


### PR DESCRIPTION
The scripts (particularly referring to the ones in the [scripts](https://github.com/evilsocket/pwnagotchi/tree/master/scripts) folder) seem to assume that there's a bash executable under the path `/bin/bash`, so I went ahead and changed all instances of shebangs from `#!/bin/bash` to `#!/usr/bin/env bash`.

I'll admit that this is a very minor change, but I believe that the upside of that said change (portability) would be a cool detail! :)