### PR TITLE
Enable  eth0 if it exists for users using other pi that are not the pi0w

### DIFF
--- a/sdcard/rootfs/etc/network/interfaces
+++ b/sdcard/rootfs/etc/network/interfaces
@@ -5,6 +5,9 @@ iface lo inet loopback
 allow-hotplug wlan0
 iface wlan0 inet static
 
+allow-hotplug eth0
+iface eth0 inet dhcp
+
 allow-hotplug usb0
 iface usb0 inet static
         address 10.0.0.2


### PR DESCRIPTION
We've been getting quite a few raspberry pi users that are not using rpi0w, which makes really hard to use the ethernet gadget mode as it would require a usb-a to usb-a cable, which is not common.

To make the experience easier, I'm adding eth0 with dhcp configuration, this way an ethernet cable can be connected and access can be done using MDNs