### PR TITLE
Add pwnagotchi preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ usage: ./scripts/create_sibling.sh [OPTIONS]
 
 #### Host Connection Share
 
-If you connect to the unit via `usb0` (thus using the data port), you might want to use the `scripts/(linux|macos)_connection_share.sh` script to bring the interface up on your end and share internet connectivity from another interface, so you can update the unit and generally download things from the internet on it.
+If you connect to the unit via `usb0` (thus using the data port), you might want to use the `scripts/linux_connection_share.sh` script to bring the interface up on your end and share internet connectivity from another interface, so you can update the unit and generally download things from the internet on it.
 
 ### UI
 
@@ -98,7 +98,6 @@ Pwnagotchi is able to speak multiple languages!! Currently supported are:
 
 * **english** (default)
 * german
-* dutch
 
 If you want to add a language use the `language.sh` script.
 If you want to add for example the language **italian** you would type:
@@ -119,6 +118,14 @@ If you changed the `voice.py`- File, the translations need an update. Do it like
 # sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/locale/it/LC_MESSAGES/voice.po
 ./scripts/language.sh compile it
 # DONE
+```
+
+Now you can use the `preview.py`-script to preview the changes:
+
+```shell
+./scripts/preview.py --lang it --display ws2 --port 8080 &
+./scripts/preview.py --lang it --display inky --port 8081 &
+# Now open http://localhost:8080 and http://localhost:8081
 ```
 
 ### Random Info

--- a/scripts/language.sh
+++ b/scripts/language.sh
@@ -55,6 +55,7 @@ function update_lang() {
   msgmerge --update "$LOCALE_DIR/$1/LC_MESSAGES/voice.po" "$LOCALE_DIR/voice.pot"
 }
 
+
 case "$1" in
   add)
     add_lang "$2"

--- a/scripts/preview.py
+++ b/scripts/preview.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import time
+import argparse
+import random
+from http.server import HTTPServer
+import shutil
+import yaml
+sys.path.insert(0,
+                os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                             '../sdcard/rootfs/root/pwnagotchi/scripts/'))
+
+from pwnagotchi.ui.view import View
+from pwnagotchi.ui.display import Display, VideoHandler
+import core
+
+class CustomDisplay(Display):
+
+    def _http_serve(self):
+        if self._video_address is not None:
+            self._httpd = HTTPServer((self._video_address, self._video_port),
+                                    CustomVideoHandler)
+            core.log("ui available at http://%s:%d/" % (self._video_address,
+                                                        self._video_port))
+            self._httpd.serve_forever()
+        else:
+            core.log("could not get ip of usb0, video server not starting")
+
+
+    def _on_view_rendered(self, img):
+        CustomVideoHandler.render(img)
+
+        if self._enabled:
+            self.canvas = (img if self._rotation == 0 else img.rotate(self._rotation))
+            if self._render_cb is not None:
+                self._render_cb()
+
+
+class CustomVideoHandler(VideoHandler):
+
+    @staticmethod
+    def render(img):
+        with CustomVideoHandler._lock:
+            img.save("/tmp/pwnagotchi-{rand}.png".format(rand=id(CustomVideoHandler)), format='PNG')
+
+    def do_GET(self):
+        if self.path == '/':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            try:
+                self.wfile.write(
+                    bytes(
+                        self._index %
+                        ('localhost', 1000), "utf8"))
+            except BaseException:
+                pass
+
+        elif self.path.startswith('/ui'):
+            with self._lock:
+                self.send_response(200)
+                self.send_header('Content-type', 'image/png')
+                self.end_headers()
+                try:
+                    with open("/tmp/pwnagotchi-{rand}.png".format(rand=id(CustomVideoHandler)), 'rb') as fp:
+                        shutil.copyfileobj(fp, self.wfile)
+                except BaseException:
+                    pass
+        else:
+            self.send_response(404)
+
+
+class DummyPeer:
+    @staticmethod
+    def name():
+        return "beta"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This program emulates\
+                                     the pwnagotchi display")
+    parser.add_argument('--display', help="Which display to use.",
+                        default="waveshare_2")
+    parser.add_argument('--port', help="Which port to use",
+                        default=8080)
+    parser.add_argument('--sleep', type=int, help="Time between emotions",
+                        default=2)
+    parser.add_argument('--lang', help="Language to use",
+                        default="en")
+    args = parser.parse_args()
+
+    CONFIG = yaml.load('''
+    main:
+        lang: {lang}
+    ui:
+        fps: 0.3
+        display:
+            enabled: false
+            rotation: 180
+            color: black
+            refresh: 30
+            type: {display}
+            video:
+                enabled: true
+                address: "127.0.0.1"
+                port: {port}
+    '''.format(display=args.display,
+               port=args.port,
+               lang=args.lang),
+                       Loader=yaml.FullLoader)
+
+    DISPLAY = CustomDisplay(config=CONFIG, state={'name': '%s>' % 'preview'})
+
+    while True:
+        DISPLAY.on_starting()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_ai_ready()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_normal()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_new_peer(DummyPeer())
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_lost_peer(DummyPeer())
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_free_channel('6')
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.wait(args.sleep)
+        DISPLAY.update()
+        DISPLAY.on_bored()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_sad()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_motivated(1)
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_demotivated(-1)
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_excited()
+        DISPLAY.update()
+        time.sleep(args.sleep)
+        DISPLAY.on_deauth({'mac': 'DE:AD:BE:EF:CA:FE'})
+        DISPLAY.update()
+
+
+if __name__ == '__main__':
+    SystemExit(main())


### PR DESCRIPTION
I tried to implement a small preview for the pwnagotchi display (currently waveshare v2 specs).

So while creating a new translation, you can open the preview with:

`./scripts/languange.sh test`

It should look like this:
![Test](https://i.imgur.com/uyJFkpM.png)

You get a rough estimation of the text width and invalid characters are displayed as "blocks".

You need a internet connection, because it will download 2 Fonts.
1. DejaVu Sans
2. LastResort (this will catch all the invalid characters which can't be displayed)

It's just an idea i had and needs some testing...