### PR TITLE
Fix for the segmentation fault in qemu

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -160,7 +160,7 @@ function provision_raspbian() {
 
   # install bettercap
   export GOPATH=/root/go
-  go get -u github.com/bettercap/bettercap
+  taskset -c 1 go get -u github.com/bettercap/bettercap
   mv "\$GOPATH/bin/bettercap" /usr/bin/bettercap
 
   # install bettercap caplets (cant run bettercap in chroot)


### PR DESCRIPTION
Without this I'm getting a constant segmentation fault when running go under qemu on Fedora 30:

+ export GOPATH=/root/go
+ GOPATH=/root/go
+ go get -u github.com/bettercap/bettercap
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
bin/bash: line 52: 23146 Segmentation fault      (core dumped) go get -u github.com/bettercap/bettercap

https://bugs.launchpad.net/qemu/+bug/1696773