### PR TITLE
Default to 8GB Images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 - sudo update-binfmts --display
 - unset GOROOT
 script:
-- sudo ./scripts/create_sibling.sh -n pwnagotchi -o pwnagotchi.img -s 8
+- sudo ./scripts/create_sibling.sh -n pwnagotchi -o pwnagotchi.img
 - zip -s 2g pwnagotchi.zip pwnagotchi.img
 
 # TODO: deploy!

--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -13,7 +13,7 @@ THIS_DIR=$(pwd)
 
 PWNI_NAME="pwnagotchi"
 PWNI_OUTPUT="pwnagotchi.img"
-PWNI_SIZE="4"
+PWNI_SIZE="8"
 
 OPT_SPARSE=0
 OPT_PROVISION_ONLY=0


### PR DESCRIPTION
hey,

currently it's not possible to build an image without setting the image size manually to 8gb. There is already a workaround in travis.yml which imho should be moved to the create_sibling.sh script. 

