### PR TITLE
Fix initial non-existent/empty log issue

### DIFF
--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/log.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/log.py
@@ -160,6 +160,9 @@ class SessionParser(object):
                         break
             lines.reverse()
 
+        if len(lines) == 0:
+            lines.append("Initial Session");
+
         self.last_session = lines
         self.last_session_id = hashlib.md5(lines[0].encode()).hexdigest()
         self.last_saved_session_id = self._get_last_saved_session_id()


### PR DESCRIPTION
Fixes bug where on initial session there is no file, and thus no lines
are read and one thus gets a index out of bounds error as lines is empty...