### PR TITLE
Friend status is positioned based on %age of screen height

### DIFF
--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/view.py
@@ -86,8 +86,8 @@ class View(object):
 
             'face': Text(value=faces.SLEEP, position=face_pos, color=BLACK, font=fonts.Huge),
 
-            'friend_face': Text(value=None, position=(0, 90), font=fonts.Bold, color=BLACK),
-            'friend_name': Text(value=None, position=(40, 93), font=fonts.BoldSmall, color=BLACK),
+            'friend_face': Text(value=None, position=(0, (self._height * 0.88) - 15 ), font=fonts.Bold, color=BLACK),
+            'friend_name': Text(value=None, position=(40,(self._height * 0.88) - 13 ), font=fonts.BoldSmall, color=BLACK),
 
             'name': Text(value='%s>' % 'pwnagotchi', position=name_pos, color=BLACK, font=fonts.Bold),
 


### PR DESCRIPTION
It takes its queue from the bottom line and places text above it.
Tested on WaveShare v2 and Inkyphat.

Potential further improvement is getting the font height, and using that as the basis for the positioning, including a buffer.