### PR TITLE
Updated depends, updated bmap check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,17 @@ For hackers to learn reinforcement learning, WiFi networking and have an excuse 
 - [Project Twitter](https://twitter.com/pwnagotchi)
 - [Project Website](https://pwnagotchi.ai/)
 
+## Known Bugs
+
+- GLib-ERROR **: 20:50:46.361: getauxval () failed: No such file or directory
+
+Affected DEB & Versions: QEMU <=2.11 
+
+Fix: Upgrade QEMU to >=3.1
+
+Bug Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923289
+
 ## License
 
 `pwnagotchi` is made with ♥  by [@evilsocket](https://twitter.com/evilsocket) and the [amazing dev team](https://github.com/evilsocket/pwnagotchi/graphs/contributors). It's released under the GPL3 license.
-
-
 

--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -95,10 +95,11 @@ function setup_raspbian(){
   # Detect the ability to create sparse files
   if [ "${OPT_SPARSE}" -eq 0 ]; then
     if [ which bmaptool -eq 0 ]; then
+      echo "[!] bmaptool not available, not creating a sparse image"
+      
+    else
       echo "[+] Defaulting to sparse image generation as bmaptool is available"
       OPT_SPARSE=1
-    else
-      echo "[!] bmaptool not available, not creating a sparse image"
     fi
   fi
 

--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -5,7 +5,7 @@
 set -eu
 
 REQUIREMENTS=( wget gunzip git dd e2fsck resize2fs parted losetup qemu-system-x86_64 )
-DEBREQUIREMENTS=( wget gzip git parted qemu-system-x86 qemu-user-static bmap-tools )
+DEBREQUIREMENTS=( wget gzip git parted qemu-system-x86 qemu-user-static )
 REPO_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
 TMP_DIR="${REPO_DIR}/tmp"
 MNT_DIR="${TMP_DIR}/mnt"
@@ -93,11 +93,8 @@ function provide_raspbian() {
 
 function setup_raspbian(){
   # Detect the ability to create sparse files
-  if [ "${OPT_SPARSE}" -eq 0 ];
-  then
-    which bmaptool >/dev/null 2>&1
-    if [ $? -eq 0 ];
-    then
+  if [ "${OPT_SPARSE}" -eq 0 ]; then
+    if [ which bmaptool -eq 0 ]; then
       echo "[+] Defaulting to sparse image generation as bmaptool is available"
       OPT_SPARSE=1
     else


### PR DESCRIPTION
Removed bmap-tools from depends as the check on line 96 looks for bmaptools and would use it if available if not continue to build, but have it as a depend check made the check null and if someone is on a kernel/file-system that does not support SEEK_HOLE and SEEK_DATA the script stops and asks to install bmap-tools and causes an error during creation when using bmap-tools if the system does not support SEEK_HOLE and SEEK_DATA

Updated bmap-tools check as the line which bmaptool >/dev/null 2>&1 did not return 0 so it kept ending at this line, with bmap-tools not installed

The original code below looks for sparse to be 0 and if which bmaptool >/dev/null 2>&1 returns 0 to use bmap-tools, but I think its the reverse so swapped the last then and else sections as it would then look if sparse is 0 and which bmaptool >/dev/null 2>&1 is 0 to not use bmap-tools, but if it is 1 to use bmap-tools. If tool is available = 1 use bmap-tools, if tools is unavailable=0 do not use bmap-tools:

if [ "${OPT_SPARSE}" -eq 0 ];
  then
    which bmaptool >/dev/null 2>&1
    if [ $? -eq 0 ];
    then
      echo "[+] Defaulting to sparse image generation as bmaptool is available"
      OPT_SPARSE=1