### PR TITLE
Fixed Render crashing main thread

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -341,7 +341,7 @@ gender[1]="girl"
 
 rand=$[ $RANDOM % 2 ]
 
-echo -e "[+] Congratz, it's a ${arr[$rand]} (⌐■_■)!"
+echo -e "[+] Congratz, it's a ${gender[$rand]} (⌐■_■)!"
 echo -e "[+] One more step: dd if=../${PWNI_OUTPUT} of=<PATH_TO_SDCARD> bs=4M status=progress"
 
 if [ "${OPT_SPARSE}" -eq 1 ];

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/display.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/ui/display.py
@@ -190,7 +190,10 @@ class Display(View):
             ])
 
         self._display.set_image(img_buffer)
-        self._display.show()
+        try:
+            self._display.show()
+        except:
+            print("")
 
     def _papirus_render(self):
         self._display.display(self._canvas)


### PR DESCRIPTION
I noticed while doing some TFT / SPI work that the renders can crash the main thread locking up the program with

```
[2019-10-04 00:44:15,060] [INFO] started advertiser thread (period:0.3 sid:ae:76:42:79:14:93) ...
Unhandled exception in thread started by <bound method Agent._event_poller of <pwnagotchi.agent.Agent object at 0x757ad2d0>>
Traceback (most recent call last):
  File "/root/pwnagotchi/scripts/pwnagotchi/agent.py", line 337, in _event_poller
    self._update_peers()
  File "/root/pwnagotchi/scripts/pwnagotchi/agent.py", line 290, in _update_peers
    self._view.set_closest_peer(peer)
  File "/root/pwnagotchi/scripts/pwnagotchi/ui/view.py", line 211, in set_closest_peer
    self.update()
  File "/root/pwnagotchi/scripts/pwnagotchi/ui/view.py", line 330, in update
    cb(self._canvas)
  File "/root/pwnagotchi/scripts/pwnagotchi/ui/display.py", line 203, in _on_view_rendered
    self._render_cb()
  File "/root/pwnagotchi/scripts/pwnagotchi/ui/display.py", line 178, in _inky_render
    self._display.show()
  File "/usr/local/lib/python3.7/dist-packages/inky/inky.py", line 325, in show
    self._update(buf_a, buf_b, busy_wait=busy_wait)
  File "/usr/local/lib/python3.7/dist-packages/inky/inky.py", line 238, in _update
    self.setup()
  File "/usr/local/lib/python3.7/dist-packages/inky/inky.py", line 213, in setup
    self._spi.open(0, self.cs_pin)
FileNotFoundError: [Errno 2] No such file or directory
[2019-10-04 00:44:24,882] [WARNING] From /usr/local/lib/python3.7/dist-packages/tensorflow/__init__.py:98: The name tf.AUTO_REUSE is deprecated. Please use tf.compat.v1.AUTO_REUSE instead.

```
I have updated the code to work around this, makes the webserver tons happy

also fixed my gender script to call the array correctly
