### PR TITLE
Configure plugins via config.yml

### DIFF
--- a/sdcard/rootfs/root/pwnagotchi/config.yml
+++ b/sdcard/rootfs/root/pwnagotchi/config.yml
@@ -6,8 +6,21 @@ main:
     custom_plugins:
     # which plugins to load and enable
     plugins:
-        - gps
-        - twitter
+      gps:
+        enabled: false
+      twitter:
+        enabled: false
+        consumer_key: aaa
+        consumer_secret: aaa
+        access_token_key: aaa
+        access_token_secret: aaa
+      onlinehashcrack:
+        enabled: false
+        email: ~
+      wpa-sec:
+        enabled: false
+        api_key: ~
+
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already
@@ -114,13 +127,6 @@ ui:
             address: '10.0.0.2'
             port: 8080
 
-# twitter bot data
-twitter:
-    enabled: false
-    consumer_key: aaa
-    consumer_secret: aaa
-    access_token_key: aaa
-    access_token_secret: aaa
 
 # bettercap rest api configuration
 bettercap:

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/__init__.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/__init__.py
@@ -43,12 +43,18 @@ def load_from_path(path, enabled=()):
 
 
 def load(config):
-    enabled = config['main']['plugins']
+    enabled = [name for name, options in config['main']['plugins'].items() if 'enabled' in options and options['enabled']]
     custom_path = config['main']['custom_plugins'] if 'custom_plugins' in config['main'] else None
     # load default plugins
-    load_from_path(default_path, enabled=enabled)
+    loaded = load_from_path(default_path, enabled=enabled)
+    # set the options
+    for name, plugin in loaded.items():
+        plugin.__dict__['OPTIONS'] = config['main']['plugins'][name]
     # load custom ones
     if custom_path is not None:
-        load_from_path(custom_path, enabled=enabled)
+        loaded = load_from_path(custom_path, enabled=enabled)
+        # set the options
+        for name, plugin in loaded.items():
+            plugin.__dict__['OPTIONS'] = config['main']['plugins'][name]
 
     on('loaded')

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/example.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/example.py
@@ -11,6 +11,9 @@ from pwnagotchi.ui.view import BLACK
 import pwnagotchi.ui.fonts as fonts
 
 
+# Will be set with the options in config.yml config['main']['plugins'][__name__]
+OPTIONS = dict()
+
 # called when the plugin is loaded
 def on_loaded():
     logging.warning("WARNING: plugin %s should be disabled!" % __name__)

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/onlinehashcrack.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/onlinehashcrack.py
@@ -9,8 +9,8 @@ import logging
 import requests
 
 READY = False
-EMAIL = None
 ALREADY_UPLOADED = None
+OPTIONS = dict()
 
 
 def on_loaded():
@@ -21,8 +21,8 @@ def on_loaded():
     global EMAIL
     global ALREADY_UPLOADED
 
-    if not EMAIL:
-        logging.error("OHC: EMAIL isn't set. Can't upload to onlinehashcrack.com")
+    if not 'email' in OPTIONS or ('email' in OPTIONS and OPTIONS['email'] is None):
+        logging.error("OHC: Email isn't set. Can't upload to onlinehashcrack.com")
         return
 
     try:
@@ -40,7 +40,7 @@ def _upload_to_ohc(path, timeout=30):
     Uploads the file to onlinehashcrack.com
     """
     with open(path, 'rb') as file_to_upload:
-        data = {'email': EMAIL}
+        data = {'email': OPTIONS['email']}
         payload = {'file': file_to_upload}
 
         try:

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/twitter.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/twitter.py
@@ -7,6 +7,7 @@ __description__ = 'This plugin creates tweets about the recent activity of pwnag
 import logging
 from pwnagotchi.voice import Voice
 
+OPTIONS = dict()
 
 def on_loaded():
     logging.info("twitter plugin loaded.")
@@ -14,7 +15,7 @@ def on_loaded():
 
 # called in manual mode when there's internet connectivity
 def on_internet_available(ui, config, log):
-    if config['twitter']['enabled'] and log.is_new() and log.handshakes > 0:
+    if log.is_new() and log.handshakes > 0:
         try:
             import tweepy
         except ImportError:
@@ -32,8 +33,8 @@ def on_internet_available(ui, config, log):
         ui.update(force=True)
 
         try:
-            auth = tweepy.OAuthHandler(config['twitter']['consumer_key'], config['twitter']['consumer_secret'])
-            auth.set_access_token(config['twitter']['access_token_key'], config['twitter']['access_token_secret'])
+            auth = tweepy.OAuthHandler(OPTIONS['consumer_key'], OPTIONS['consumer_secret'])
+            auth.set_access_token(OPTIONS['access_token_key'], OPTIONS['access_token_secret'])
             api = tweepy.API(auth)
 
             tweet = Voice(lang=config['main']['lang']).on_log_tweet(log)

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/wpa-sec.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/wpa-sec.py
@@ -9,7 +9,6 @@ import logging
 import requests
 
 READY = False
-API_KEY = None
 ALREADY_UPLOADED = None
 
 
@@ -21,7 +20,7 @@ def on_loaded():
     global API_KEY
     global ALREADY_UPLOADED
 
-    if not API_KEY:
+    if not 'api_key' in OPTIONS or ('api_key' in OPTIONS and OPTIONS['api_key'] is None):
         logging.error("WPA_SEC: API-KEY isn't set. Can't upload to wpa-sec.stanev.org")
         return
 
@@ -40,7 +39,7 @@ def _upload_to_wpasec(path, timeout=30):
     Uploads the file to wpa-sec.stanev.org
     """
     with open(path, 'rb') as file_to_upload:
-        headers = {'key': API_KEY}
+        headers = {'key': OPTIONS['api_key']}
         payload = {'file': file_to_upload}
 
         try:


### PR DESCRIPTION
See #129 

Now you can configure the plugins via `config.yml`.

Each plugin has an `OPTIONS`-dict with the values in it.

You can use it like:

```yaml
main:
  plugins:
    example:
      enabled: True
      api_key: '1234567'
```

```python
if OPTIONS['enabled']:
  print('I am enabled and using the api-key ' + OPTIONS['api_key'])
```