### PR TITLE
Fix incorrect config filename in update script

### DIFF
--- a/scripts/update_pwnagotchi.sh
+++ b/scripts/update_pwnagotchi.sh
@@ -89,7 +89,7 @@ fi
 
 if [ $BACKUPCONFIG -eq 1 ]; then
     echo "[+] Creating backup of config.yml and hostname references"
-    mv /root/pwnagotchi/config.yml /root/config.bak -f
+    mv /root/pwnagotchi/config.yml /root/config.yml.bak -f
     mv /etc/hosts /root/hosts.bak -f
     mv /etc/hostname /root/hostname.bak -f
     mv /etc/motd /etc/motd.bak -f


### PR DESCRIPTION
## Description
The update script backs up the config file to `/root/config.bak`, but
then tries to restore it from `/root/config.yml.bak` (which obviously
won't be found).

This looks like a typo in the backup command, so update that command to
use the same filename as the restore command.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))  - https://github.com/evilsocket/pwnagotchi/issues/135

## How Has This Been Tested?
Ran the updated script on my pwnagotchi and confirmed that the files were backed up and restored as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
