### PR TITLE
Fix split-bug in script

### DIFF
--- a/sdcard/rootfs/root/pwnagotchi/config.yml
+++ b/sdcard/rootfs/root/pwnagotchi/config.yml
@@ -15,7 +15,7 @@ main:
         files:
           - /root/brain.nn
           - /root/brain.json
-          - /root/custom.yaml
+          - /root/custom.yml
           - /root/handshakes
           - /etc/ssh
           - /etc/hostname
@@ -24,7 +24,7 @@ main:
           - /var/log/pwnagotchi.log
         commands:
           - 'tar czf /tmp/backup.tar.gz {files}'
-          - 'scp /tmp/backup.tar.gz pwnagotchi@10.0.0.1:/home/pwnagotchi/backups/backup-$(date).tar.gz'
+          - 'scp /tmp/backup.tar.gz pwnagotchi@10.0.0.1:/home/pwnagotchi/backups/backup-$(date +%s).tar.gz'
       gps:
         enabled: false
       twitter:

--- a/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/auto-backup.py
+++ b/sdcard/rootfs/root/pwnagotchi/scripts/pwnagotchi/plugins/default/auto-backup.py
@@ -30,6 +30,7 @@ def on_loaded():
         return
 
     READY = True
+    logging.info("AUTO-BACKUP: Successfuly loaded.")
 
 
 def on_internet_available(display, config, log):
@@ -41,11 +42,17 @@ def on_internet_available(display, config, log):
 
         files_to_backup = " ".join(OPTIONS['files'])
         try:
+            logging.info("AUTO-BACKUP: Backing up ...")
             display.set('status', 'Backing up ...')
             display.update()
 
             for cmd in OPTIONS['commands']:
-                subprocess.call(cmd.format(files=files_to_backup).split(), stdout=open(os.devnull, 'wb'))
+                logging.info(f"AUTO-BACKUP: Running {cmd.format(files=files_to_backup)}")
+                process = subprocess.Popen(cmd.format(files=files_to_backup), shell=True, stdin=None,
+                                          stdout=open("/dev/null", "w"), stderr=None, executable="/bin/bash")
+                process.wait()
+                if process.returncode > 0:
+                    raise OSError(f"Command failed (rc: {process.returncode})")
 
             logging.info("AUTO-BACKUP: backup done")
             STATUS.update()


### PR DESCRIPTION
Changed method to Popen. Also changed yaml -> yml. And now the plugin is more verbose.