### PR TITLE
Fixes "No module named 'pwnagotchi'" error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='pwnagotchi',
       install_requires=required,
       scripts=['bin/pwnagotchi'],
       package_data={'pwnagotchi': ('pwnagotchi/defaults.yml',)},
+      packages=find_packages(),
       classifiers=[
           'Programming Language :: Python :: 3',
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Bug fix for installation of pwnagotchi using setup.py

## Description
This change fixes a bug with the new setup.py script if used to install the pwnagotchi software. Once installed, running '/usr/local/bin/pwnagotchi' returns the following error:                                                                                                                                                                                               Traceback (most recent call last):
  File "/usr/local/bin/pwnagotchi", line 8, in <module>
    import pwnagotchi
ModuleNotFoundError: No module named 'pwnagotchi'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required] - #171  (https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested using with the "pwnagotchi -C /root/defaults.yml --manual"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
