### PR TITLE
Updated bmaptool check #2

### DIFF
--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -94,7 +94,7 @@ function provide_raspbian() {
 function setup_raspbian(){
   # Detect the ability to create sparse files
   if [ "${OPT_SPARSE}" -eq 0 ]; then
-    if [ which bmaptool -eq 0 ]; then
+    if ! type "bmaptool" > /dev/null; then
       echo "[!] bmaptool not available, not creating a sparse image"
       
     else

--- a/scripts/create_sibling.sh
+++ b/scripts/create_sibling.sh
@@ -96,7 +96,6 @@ function setup_raspbian(){
   if [ "${OPT_SPARSE}" -eq 0 ]; then
     if ! type "bmaptool" > /dev/null; then
       echo "[!] bmaptool not available, not creating a sparse image"
-      
     else
       echo "[+] Defaulting to sparse image generation as bmaptool is available"
       OPT_SPARSE=1


### PR DESCRIPTION
When doing some testing I was able to determine the second check for bmaptool would return a false 1 and cause at the end of the create script to think bmap-tools is installed. I did some research and testing and updated it to use a different check. Also removed and extra carriage return. To test i added a couple of echo's to the if and else section to print what OPT_SPARSE was and then had it stop so I did not have to let it fully finish each time i tested it. Each time it printed OPT_SPARSE was 0 and showed the right echo line.