### PR TITLE
fixed spacing error in greek translation

### DIFF
--- a/pwnagotchi/locale/el/LC_MESSAGES/voice.po
+++ b/pwnagotchi/locale/el/LC_MESSAGES/voice.po
@@ -33,11 +33,11 @@ msgid "AI ready."
 msgstr "ΤΝ έτοιμη."
 
 msgid "The neural network is ready."
-msgstr "Το νευρωνικό δίκτυοείναι έτοιμο."
+msgstr "Το νευρωνικό δίκτυο είναι έτοιμο."
 
 #, python-brace-format
 msgid "Hey, channel {channel} is free! Your AP will say thanks."
-msgstr "Ε, το κανάλι {channel} είναιελεύθερο! Το AP σου θαείναι ευγνώμων."
+msgstr "Ε, το κανάλι {channel} είναιελεύθερο! Το AP σου θα είναι ευγνώμων."
 
 msgid "I'm bored ..."
 msgstr "Βαριέμαι ..."


### PR DESCRIPTION
I fixed two small spacing-related mistakes in the Greek translation of Pwnagotchi.

## Description
I added two spaces. That's about it, really.

## Motivation and Context
It just didn't seem quite visually pleasing.
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
It hasn't been tested, because of the triviality of the fix itself.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
