### PR TITLE
Added hdmion/hdmioff scripts

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -291,6 +291,22 @@
         #!/usr/bin/env bash
         ifconfig mon0 down && iw dev mon0 del
 
+  - name: create hdmion script
+    copy:
+      dest: /usr/bin/hdmion
+      mode: 0755
+      content: |
+        #!/usr/bin/env bash
+        sudo /opt/vc/bin/tvservice -p
+
+  - name: create hdmioff script
+    copy:
+      dest: /usr/bin/hdmioff
+      mode: 0755
+      content: |
+        #!/usr/bin/env bash
+        sudo /opt/vc/bin/tvservice -o
+
   - name: configure rc.local
     blockinfile:
       path: /etc/rc.local


### PR DESCRIPTION
## Description
Added two more sections in the Ansible file to generate the hdmion and hdmioff scripts in order to be able to (easier) turn on and off the HDMI functionality.

## Motivation and Context
I wanted to be able to turn off HDMI when I go between power and battery usage. Every little bit to save battery is worth it...

## How Has This Been Tested?
Have verified that the scripts work. Tried to build a new image but since the re-arch and loss of the sdcard folder the create_sibling.sh script currently fails. (I think issue https://github.com/evilsocket/pwnagotchi/issues/170 references this too).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

I'm not sure if this needs added to the documentation and if so where - but please point me in the right direction and I'll sort that too, possibly by creating and assigning an issue to me?