### PR TITLE
Fix bug with gps.json files

### DIFF
--- a/pwnagotchi/plugins/default/wpa-sec.py
+++ b/pwnagotchi/plugins/default/wpa-sec.py
@@ -61,7 +61,7 @@ def on_internet_available(display, config, log):
     if READY:
         handshake_dir = config['bettercap']['handshakes']
         handshake_filenames = os.listdir(handshake_dir)
-        handshake_paths = [os.path.join(handshake_dir, filename) for filename in handshake_filenames]
+        handshake_paths = [os.path.join(handshake_dir, filename) for filename in handshake_filenames if filename.endswith('.pcap')]
         handshake_new = set(handshake_paths) - set(ALREADY_UPLOADED)
 
         if handshake_new:


### PR DESCRIPTION
If you use the gps-plugin, the `.gps.json` files are also written in the handshake directory. The plugin assumed, that every file in the directory would be a pcap.