### PR TITLE
add override file check to loader

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -235,7 +235,13 @@
         /usr/bin/bootblink 10 &
         # start a detached screen session with bettercap
         if ifconfig | grep usb0 | grep RUNNING; then
-          /usr/local/bin/pwnagotchi --manual
+          # if override file exists, go into auto mode
+          if [ -f /root/.pwnagotchi-auto ]; then
+            rm /root/.pwnagotchi-auto
+            /usr/local/bin/pwnagotchi
+          else
+            /usr/local/bin/pwnagotchi --manual
+          fi
         else
           /usr/local/bin/pwnagotchi
         fi


### PR DESCRIPTION
The loader will check if the file /root/.pwnagotchi-auto exists, if it exists it will be removed and pwnagotchi will be started in auto mode.

