### PR TITLE
fix builder to set image version and hostname on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
 script:
   - sudo make clean
   - sudo -E env "PATH=$PATH" make install
-  - sudo make image -e PWN_HOSTNAME=pwnagotchi VERSION=$TRAVIS_TAG
+  - sudo make image -e PWN_HOSTNAME=pwnagotchi PWN_VERSION=$TRAVIS_TAG
 notifications:
   slack:
     secure: aovN87lswg+TTLobxJpevC0p2F4omTAlsOzeKqLysRW55o5rRhRC1SgwRkWUl19yr49nsyffwmv/b7OcyQiWIVnz1bxxE9XOKP8zgRMA/bKKcyAcPktPqHXsALIQDseXyl0kz7fwdkRWg0UC2HpKqi5koAhmBYTX/fbzieyeHCbcQ7lbFfVFIepE1401y9m1IqUHcHuGfFhMvTaSDIpXrDXnWdA8+gDAl0HKJv41MIsgmffbh/QhD2jLBWzItjxFC3llmNfy88pnzCk0+HBMY/4272LXb0czX7et5HJeM74oxPqkb3aKXFxZgNaDl7cYdV+kzj9dfKUk47hAqwbxlirit5WvHI1Br1VyA90+PFvcC/p41J8gCv0IlcB5vjWN8NKWA1J+Y1F+KvrujMvGtgd0foHZvaSutuRODhI1cBh5rYAiLCroRSlvKMw3IJRyCRstYgUlMIJ3cI2Ova/kU44KtDVmjT9VE/pPkhkHBPvcYThL6skZTdl19E/RlormLu3XObG1aHLZ+Znxe/aL7tWHi0KMOlpy+TMDdps4go7URnJ8yitHtIvU/zMtBrztIwN0Oy2JLKXrS5qIijmRAkBLxe0NxuG01DYFzEO3KtnRirP4uSe3QcrjyP4sqPrVhrjl3TR6gwg8V1juvDXB4e2h8yCpaUW5AdSBOlx9riY=

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 	cp /tmp/packer-builder-arm-image/packer-builder-arm-image /usr/bin
 
 image:
-	cd builder && sudo /usr/bin/packer build pwnagotchi.json
+	cd builder && sudo /usr/bin/packer build -var "pwn_hostname=$(PWN_HOSTNAME)" -var "pwn_version=$(PWN_VERSION)" pwnagotchi.json
 	mv builder/output-pwnagotchi/image pwnagotchi-raspbian-lite-$(PWN_VERSION).img
 	zip pwnagotchi-raspbian-lite-$(PWN_VERSION).zip pwnagotchi-raspbian-lite-$(PWN_VERSION).img
 

--- a/builder/pwnagotchi.json
+++ b/builder/pwnagotchi.json
@@ -1,7 +1,4 @@
 {
-  "variables": {
-    "home": "{{env `HOME`}}"
-  },
   "builders": [{
     "name": "pwnagotchi",
     "type": "arm-image",
@@ -22,7 +19,8 @@
     },
     {
       "type":"ansible-local",
-      "playbook_file": "pwnagotchi.yml"
+      "playbook_file": "pwnagotchi.yml",
+      "command": "ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 PWN_VERSION={{user `pwn_version`}} PWN_HOSTNAME={{user `pwn_hostname`}} ansible-playbook"
     },
     {
       "type": "shell",

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -5,7 +5,7 @@
   vars:
     pwnagotchi:
       hostname: "{{ lookup('env', 'PWN_HOSTNAME') | default('pwnagotchi', true) }}"
-      version: "{{ lookup('env', 'PWN_VERSION') | default('master', true) }} "
+      version: "{{ lookup('env', 'PWN_VERSION') | default('master', true) }}"
     system:
       boot_options:
         - "dtoverlay=dwc2"


### PR DESCRIPTION
Our builder was not respecting the hostname and version tag set on travis.

This PR fixes it.

Sadly packer is not passing variables to ansible via --extra-vars, so it was required to fill the environment first with environment variables.

I test this locally and seems to be working as expected, it adds the hostname configured to the machine and also sets the version on /etc/motd

