### PR TITLE
add papirus display system requirements

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -11,11 +11,14 @@
         - "dtoverlay=dwc2"
         - "dtparam=spi=on"
         - "dtoverlay=spi1-3cs"
+        - "dtoverlay=i2c_arm=on"
+        - "dtoverlay=i2c1=on"
     services:
       enable:
         - dphys-swapfile.service
         - pwnagotchi.service
         - bettercap.service
+        - epd-fuse.service
       disable:
         - apt-daily.timer
         - apt-daily.service
@@ -78,6 +81,10 @@
           - fonts-dejavu-core
           - fonts-dejavu-extra
           - python3-pil
+          - python3-smbus
+          - libfuse-dev
+          - bc
+          - fonts-freefont-ttf
 
   tasks:
 
@@ -133,6 +140,33 @@
     file:
       path: /etc/dphys-swapfile
       content: "CONF_SWAPSIZE=1024"
+
+  - name: clone papirus repository
+    git:
+      repo: https://github.com/repaper/gratis.git
+      dest: /usr/local/src/gratis
+
+  - name: build papirus service
+    make:
+      chdir: /usr/local/src/gratis
+      target: rpi
+      params:
+        EPD_IO: epd_io.h
+        PANEL_VERSION: 'V231_G2'
+
+  - name: install papirus service
+    make:
+      chdir: /usr/local/src/gratis
+      target: rpi-install
+      params:
+        EPD_IO: epd_io.h
+        PANEL_VERSION: 'V231_G2'
+
+  - name: configure papirus display size
+    lineinfile:
+      dest: /etc/default/epd-fuse
+      regexp: "#EPD_SIZE=2.0"
+      line: "EPD_SIZE=2.0"
 
   - name: acquire python3 pip target
     command: "python3 -c 'import sys;print(sys.path.pop())'"


### PR DESCRIPTION

## Description

This PR is related to #234 

- It downloads Pairus dependencies and installs it
- It enabled the I2C bus to allow papirus drivers to talk to it
- It enables the service required to run (epd-fuse)

<!--- Describe your changes in detail -->

## Motivation and Context
This change was motivated by the issue raised which was related to the lack of support for papirus displays on the operational system level.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I don't have a papirus to test but I could verify that all it's dependencies installed correctly based in what was reported on the issue.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

