### PR TITLE
Move handshakes folder

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -21,7 +21,7 @@ main:
         files:
           - /root/brain.nn
           - /root/brain.json
-          - /home/pi/handshakes/
+          - /var/handshakes/
           - /etc/pwnagotchi/
           - /etc/hostname
           - /etc/hosts
@@ -175,7 +175,7 @@ bettercap:
     # wifi.handshakes.aggregate will be set to false and individual
     # pcap files will be created in order to minimize the chances
     # of a single pcap file to get corrupted
-    handshakes: /home/pi/handshakes
+    handshakes: /var/handshakes
     # events to mute in bettercap's events stream
     silence:
         - ble.device.new

--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -21,7 +21,7 @@ main:
         files:
           - /root/brain.nn
           - /root/brain.json
-          - /root/handshakes/
+          - /home/pi/handshakes/
           - /etc/pwnagotchi/
           - /etc/hostname
           - /etc/hosts
@@ -175,7 +175,7 @@ bettercap:
     # wifi.handshakes.aggregate will be set to false and individual
     # pcap files will be created in order to minimize the chances
     # of a single pcap file to get corrupted
-    handshakes: /root/handshakes
+    handshakes: /home/pi/handshakes
     # events to mute in bettercap's events stream
     silence:
         - ble.device.new

--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -74,10 +74,10 @@ def parse_pcap(filename):
     net_id = os.path.basename(filename).replace('.pcap', '')
 
     if '_' in net_id:
-        # /root/handshakes/ESSID_BSSID.pcap
+        # /home/pi/handshakes/ESSID_BSSID.pcap
         essid, bssid = net_id.split('_')
     else:
-        # /root/handshakes/BSSID.pcap
+        # /home/pi/handshakes/BSSID.pcap
         essid, bssid = '', net_id
 
     it = iter(bssid)

--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -74,10 +74,10 @@ def parse_pcap(filename):
     net_id = os.path.basename(filename).replace('.pcap', '')
 
     if '_' in net_id:
-        # /home/pi/handshakes/ESSID_BSSID.pcap
+        # /var/handshakes/ESSID_BSSID.pcap
         essid, bssid = net_id.split('_')
     else:
-        # /home/pi/handshakes/BSSID.pcap
+        # /var/handshakes/BSSID.pcap
         essid, bssid = '', net_id
 
     it = iter(bssid)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -10,7 +10,7 @@ TEMP_BACKUP_FOLDER=/tmp/pwnagotchi_backup
 FILES_TO_BACKUP=(
   /root/brain.nn
   /root/brain.json
-  /home/pi/handshakes
+  /var/handshakes
   /etc/pwnagotchi/
   /etc/hostname
   /etc/hosts

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -10,7 +10,7 @@ TEMP_BACKUP_FOLDER=/tmp/pwnagotchi_backup
 FILES_TO_BACKUP=(
   /root/brain.nn
   /root/brain.json
-  /root/handshakes
+  /home/pi/handshakes
   /etc/pwnagotchi/
   /etc/hostname
   /etc/hosts


### PR DESCRIPTION
In `RC2` noticed `Temporary failure in name resolution` while accessing handshakes over ssh. In fact, I could not access pcaps at all until moved them in the user dir.