### PR TITLE
Only show ui complication if you have unread pwnmail

### DIFF
--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -65,7 +65,7 @@ def is_excluded(what):
 
 def on_ui_update(ui):
     new_value = ' %d (%d)' % (UNREAD_MESSAGES, TOTAL_MESSAGES)
-    if not ui.has_element('mailbox') and TOTAL_MESSAGES > 0:
+    if not ui.has_element('mailbox') and UNREAD_MESSAGES > 0:
         if ui.is_inky():
             pos = (80, 0)
         else:


### PR DESCRIPTION
## Description
Changed UI logic in the Grid plugin to only display details if you have unread messages instead of any messages at all

## Motivation and Context
There's no reason for a visual indicator if you've read all of your messages, and it's a little satisfying to clear the "notification" once the inbox is all dealt with.
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
It just works™

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
