### PR TITLE
Minor fixes to the UI to prevent overlap 

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -74,6 +74,8 @@ main:
         netmask: 24
         interval: 1 # check every x minutes for device
         share_internet: false
+      memtemp: # Display memory usage and cpu temperature on screen
+        enabled: false 
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already

--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -491,5 +491,5 @@ def on_ui_update(ui):
 
 
 def on_ui_setup(ui):
-    ui.add_element('bluetooth', LabeledValue(color=BLACK, label='BT', value='-', position=(ui.width() / 2 - 30, 0),
+    ui.add_element('bluetooth', LabeledValue(color=BLACK, label='BT', value='-', position=(ui.width() / 2 - 15, 0),
                                        label_font=fonts.Bold, text_font=fonts.Medium))

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -2,8 +2,19 @@
 #
 # totalmem usedmem freemem cputemp
 #
+###############################################################
+#
+# Updated 18-10-2019 by spees <speeskonijn@gmail.com>
+# - Changed the place where the data was displayed on screen
+# - Made the data a bit more compact and easier to read
+# - removed the label so we wont waste screen space
+# - Updated version to 1.0.1
+#
+###############################################################
+
+
 __author__ = 'https://github.com/xenDE'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __name__ = 'memtemp'
 __license__ = 'GPL3'
 __description__ = 'A plugin that will add a memory and temperature indicator'
@@ -21,9 +32,9 @@ class MEMTEMP:
 
     # set the minimum seconds before refresh the values
     refresh_wait = 30
-    
+
     refresh_ts_last = time.time() - refresh_wait
-    
+
     def __init__(self):
         # only import when the module is loaded and enabled
         import os
@@ -31,9 +42,9 @@ class MEMTEMP:
     def get_temp(self):
         try:
             temp = os.popen('/opt/vc/bin/vcgencmd measure_temp').readlines()[0].split('=')[1].replace("\n", '').replace("'","")
-            return 'cpu:' + temp
+            return 't:' + temp
         except:
-            return 'cpu:0.0C'
+            return 't:-'
         # cpu:37.4C
 
     def get_mem_info(self):
@@ -42,9 +53,9 @@ class MEMTEMP:
 #            total, used, free = map(int, os.popen('free -t -m').readlines()[-1].split()[1:])
             # without Swap, only real memory:
             total, used, free = map(int, os.popen('free -t -m').readlines()[-3].split()[1:4])
-            return "tm:"+str(total)+" um:"+str(used)+" fm:"+str(free)
+            return "\nT:"+str(total)+"M U:"+str(used)+"M\nF:"+str(free)+"M"
         except:
-            return "tm:0 um:0 fm:0"
+            return "\nT:-  U:-\nF:- "
         # tm:532 um:82 fm:353
 
 
@@ -57,7 +68,7 @@ def on_loaded():
 
 
 def on_ui_setup(ui):
-    ui.add_element('memtemp', LabeledValue(color=BLACK, label='SYS', value='tm:0 um:0 fm:0 0.0C', position=(0, ui.height()-28),
+    ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value='\nT:-  U:-\nF:- -', position=(ui.width() / 2 + 17, ui.height() / 2),
                                        label_font=fonts.Bold, text_font=fonts.Medium))
 
 
@@ -65,4 +76,5 @@ def on_ui_update(ui):
     if time.time() > memtemp.refresh_ts_last + memtemp.refresh_wait:
         ui.set('memtemp', "%s %s" % (memtemp.get_mem_info(), memtemp.get_temp()))
         memtemp.refresh_ts_last = time.time()
+
 

--- a/pwnagotchi/ui/hw/inky.py
+++ b/pwnagotchi/ui/hw/inky.py
@@ -16,7 +16,7 @@ class Inky(DisplayImpl):
         self._layout['face'] = (0, 37)
         self._layout['name'] = (5, 18)
         self._layout['channel'] = (0, 0)
-        self._layout['aps'] = (25, 0)
+        self._layout['aps'] = (30, 0)
         self._layout['uptime'] = (147, 0)
         self._layout['line1'] = [0, 12, 212, 12]
         self._layout['line2'] = [0, 92, 212, 92]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

On inky displays, the last total recon APs status sometimes overlaps with the channel status depending on the channel it is on.

The BT status overlaps with the last total recon status. This might be an issue only on inky displays, but since this is controlled by the bt-tether plugin it will apply to all screens.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Making the UI not showing garbage on the display. This makes all statuses show correctly and readable.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/evilsocket/pwnagotchi/issues/315

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
After the changes the UI looks clean and no more overlap.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
