### PR TITLE
increase version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gym==0.14.0
 stable-baselines==2.7.0
 tensorflow==1.13.1
 tensorflow-estimator==1.14.0
-tweepy==3.6.0
+tweepy==3.7.0
 file-read-backwards==2.0.0
 numpy==1.17.2
 inky==0.0.5


### PR DESCRIPTION
See #258 

Tested with the newest version (v1.0.1)

python3 -c "import tweepy" crashes