### PR TITLE
Fix Origin header check bypass

### DIFF
--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -141,7 +141,7 @@ class Handler(BaseHTTPRequestHandler):
             return False
 
         if Handler.AllowedOrigin != '*':
-            if origin != Handler.AllowedOrigin and not origin.starts_with(Handler.AllowedOrigin):
+            if origin != Handler.AllowedOrigin:
                 logging.warning("request with blocked Origin from %s: %s" % (self.address_string(), origin))
                 return False
 

--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -136,7 +136,7 @@ class Handler(BaseHTTPRequestHandler):
     # check the Origin header vs CORS
     def _is_allowed(self):
         origin = self.headers.get('origin')
-        if origin == "":
+        if not origin:
             logging.warning("request with no Origin header from %s" % self.address_string())
             return False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
```python
Handler.AllowedOrigin = 'https://safe.com'
origin = 'https://safe.com.evil.com'

origin.startswith(Handler.AllowedOrigin) == True
```

Not really bypass, since it has typo `starts_with` -> `startswith`, but if you fixed typo..

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
