### PR TITLE
vibrate plugin for haptic feedback without needing a screen

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -51,7 +51,9 @@ main:
       screen_refresh:
         enabled: false
         refresh_interval: 50
-
+      vibrate:
+        enabled: false
+        vPin: 21
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already

--- a/pwnagotchi/plugins/default/vibrate.py
+++ b/pwnagotchi/plugins/default/vibrate.py
@@ -1,0 +1,30 @@
+__author__ = 'pwnagotchi [at] rossmarks [dot] uk'
+__version__ = '1.0.0'
+__name__ = 'vibrate'
+__license__ = 'GPL3'
+__description__ = 'quick vibrate once handshake captured for feedback when screen not accessible'
+
+import logging
+import time
+import RPi.GPIO as GPIO
+
+OPTIONS = dict()
+
+def on_loaded():
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+    GPIO.setup(OPTIONS['vPin'],GPIO.OUT)
+    logging.info("vibrate plugin loaded")
+    GPIO.output(OPTIONS['vPin'],GPIO.HIGH)
+    time.sleep(0.5)
+    GPIO.output(OPTIONS['vPin'],GPIO.LOW)
+
+def on_handshake(agent, filename, access_point, client_station):
+    logging.info("[vibrate] Got handshake - vibrating")
+    GPIO.output(OPTIONS['vPin'],GPIO.HIGH)
+    time.sleep(0.5)
+    GPIO.output(OPTIONS['vPin'],GPIO.LOW)
+    time.sleep(0.5)
+    GPIO.output(OPTIONS['vPin'],GPIO.HIGH)
+    time.sleep(0.5)
+    GPIO.output(OPTIONS['vPin'],GPIO.LOW)


### PR DESCRIPTION
## Description
Solder small vibration motor to pin 40 (GPIO 21) and ground (pin 39)
this will vibrate the motor every time a handshake is captured so you no longer need to look a the screen or even have one!

## Motivation and Context
I wanted it

## How Has This Been Tested?
work on mine

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
