### PR TITLE
Make wpa-sec URL configurable, part 1.

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -58,6 +58,7 @@ main:
         wpa-sec:
             enabled: false
             api_key: ~
+            api_url: "https://wpa-sec.stanev.org"
         wigle:
             enabled: false
             api_key: ~


### PR DESCRIPTION
Part 1 of closing https://github.com/evilsocket/pwnagotchi/issues/347, doing this from a device with only browser access to GH so will be done across 2 PR's.