### PR TITLE
papirus, fbi and idempotency changes

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -9,10 +9,12 @@
     system:
       boot_options:
         - "dtoverlay=dwc2"
-        - "dtparam=spi=on"
         - "dtoverlay=spi1-3cs"
-        - "dtoverlay=i2c_arm=on"
-        - "dtoverlay=i2c1=on"
+        - "dtparam=spi=on"
+        - "dtparam=i2c_arm=on"
+        - "dtparam=i2c1=on"
+      modules:
+        - "i2c-dev"
     services:
       enable:
         - dphys-swapfile.service
@@ -95,27 +97,22 @@
           - libfuse-dev
           - bc
           - fonts-freefont-ttf
+          - fbi
 
   tasks:
-
-  - name: selected hostname
-    debug:
-      msg: "{{ pwnagotchi.hostname }}"
-
-  - name: build version
-    debug:
-      msg: "{{ pwnagotchi.version }}"
-
   - name: change hostname
     hostname:
       name: "{{pwnagotchi.hostname}}"
+    when: lookup('file', '/etc/hostname') == "raspberrypi"
+    register: hostname
 
   - name: add hostname to /etc/hosts
     lineinfile:
       dest: /etc/hosts
-      regexp: '^127\.0\.0\.1[ \t]+localhost'
-      line: '127.0.0.1 localhost {{pwnagotchi.hostname}} {{pwnagotchi.hostname}}.local'
+      regexp: '^127\.0\.1\.1[ \t]+raspberrypi'
+      line: '127.0.1.1\t{{pwnagotchi.hostname}}'
       state: present
+    when: hostname.changed
 
   - name: Add re4son-kernel repo key
     apt_key:
@@ -161,6 +158,7 @@
     git:
       repo: https://github.com/repaper/gratis.git
       dest: /usr/local/src/gratis
+    register: gratisgit
 
   - name: build papirus service
     make:
@@ -169,6 +167,7 @@
       params:
         EPD_IO: epd_io.h
         PANEL_VERSION: 'V231_G2'
+    when: gratisgit.changed
 
   - name: install papirus service
     make:
@@ -177,12 +176,23 @@
       params:
         EPD_IO: epd_io.h
         PANEL_VERSION: 'V231_G2'
+    when: gratisgit.changed
 
   - name: configure papirus display size
     lineinfile:
       dest: /etc/default/epd-fuse
       regexp: "#EPD_SIZE=2.0"
       line: "EPD_SIZE=2.0"
+
+  - name: collect python pip package list
+    command: "pip3 list"
+    register: pip_output
+
+  - name: set python pip package facts
+    set_fact:
+      pip_packages: >
+        {{ pip_packages | default({}) | combine( { item.split()[0]: item.split()[1] } ) }}
+    with_items: "{{ pip_output.stdout_lines }}"
 
   - name: acquire python3 pip target
     command: "python3 -c 'import sys;print(sys.path.pop())'"
@@ -192,26 +202,39 @@
     git:
       repo: https://github.com/evilsocket/pwnagotchi.git
       dest: /usr/local/src/pwnagotchi
+    register: pwnagotchigit
+
+  - name: fetch pwnagotchi version
+    set_fact:
+      pwnagotchi_version: "{{ lookup('file', '/usr/local/src/pwnagotchi/pwnagotchi/__init__.py') | replace('\n', ' ') | regex_replace('.*version.*=.*''([0-9]+\\.[0-9]+\\.[0-9]+[A-Za-z0-9]*)''.*', '\\1') }}"
+
+  - name: pwnagotchi version found
+    debug:
+      msg: "{{ pwnagotchi_version }}"
 
   - name: build pwnagotchi wheel
     command: "python3 setup.py sdist bdist_wheel"
     args:
       chdir: /usr/local/src/pwnagotchi
+    when: (pwnagotchigit.changed) or (pip_packages['pwnagotchi'] is undefined) or (pip_packages['pwnagotchi'] != pwnagotchi.version)
 
   - name: install opencv-python
     pip:
       name: "https://www.piwheels.hostedpi.com/simple/opencv-python/opencv_python-3.4.3.18-cp37-cp37m-linux_armv6l.whl"
       extra_args: "--no-deps --no-cache-dir --platform=linux_armv6l --only-binary=:all: --target={{ pip_target.stdout }}"
+    when: (pip_packages['opencv-python'] is undefined) or (pip_packages['opencv-python'] != '3.4.3.18')
 
   - name: install tensorflow
     pip:
       name: "https://www.piwheels.hostedpi.com/simple/tensorflow/tensorflow-1.13.1-cp37-none-linux_armv6l.whl"
       extra_args: "--no-deps --no-cache-dir --platform=linux_armv6l --only-binary=:all: --target={{ pip_target.stdout }}"
+    when: (pip_packages['tensorflow'] is undefined) or (pip_packages['tensorflow'] != '1.13.1')
 
   - name: install pwnagotchi wheel and dependencies
     pip:
       name: "{{ lookup('fileglob', '/usr/local/src/pwnagotchi/dist/pwnagotchi*.whl') }}"
       extra_args: "--no-cache-dir"
+    when: (pwnagotchigit.changed) or (pip_packages['pwnagotchi'] is undefined) or (pip_packages['pwnagotchi'] != pwnagotchi.version)
 
   - name: download and install pwngrid
     unarchive:
@@ -234,11 +257,13 @@
     git:
       repo: https://github.com/bettercap/caplets.git
       dest: /tmp/caplets
+    register: capletsgit
 
   - name: install bettercap caplets
     make:
       chdir: /tmp/caplets
       target: install
+    when: capletsgit.changed
 
   - name: download and install bettercap ui
     unarchive:
@@ -246,26 +271,6 @@
       dest: /usr/local/share/bettercap/
       remote_src: yes
       mode: 0755
-
-  - name: create cpuusage script
-    copy:
-      dest: /usr/bin/cpuusage
-      mode: 0755
-      content: |
-        #!/usr/bin/env bash
-        while true
-        do
-          top -b -n1 | awk '/Cpu\(s\)/ { printf("%d %", $2 + $4 + 0.5) }'
-          sleep 3
-        done
-
-  - name: create memusage script
-    copy:
-      dest: /usr/bin/memusage
-      mode: 0755
-      content: |
-        #!/usr/bin/env bash
-        free -m | awk '/Mem/ { printf( "%d %", $3 / $2 * 100 + 0.5 ) }'
 
   - name: create bootblink script
     copy:
@@ -434,6 +439,13 @@
       line: '{{ item }}'
     with_items: "{{system.boot_options}}"
 
+  - name: adjust /etc/modules
+    lineinfile:
+      dest: /etc/modules
+      insertafter: EOF
+      line: '{{ item }}'
+    with_items: "{{system.modules}}"
+
   - name: change root partition
     replace:
       dest: /boot/cmdline.txt
@@ -480,6 +492,7 @@
         touch /root/.pwnagotchi-auto && systemctl restart pwnagotchi
 
         You learn more about me at https://pwnagotchi.ai/
+    when: hostname.changed
 
   - name: clean apt cache
     apt:

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -114,6 +114,13 @@
       state: present
     when: hostname.changed
 
+  - name: disable sap plugin for bluetooth.service
+    lineinfile:
+      dest: /lib/systemd/system/bluetooth.service
+      regexp: '^ExecStart=/usr/lib/bluetooth/bluetoothd$'
+      line: 'ExecStart=/usr/lib/bluetooth/bluetoothd --noplugin=sap'
+      state: present
+
   - name: Add re4son-kernel repo key
     apt_key:
       url: https://re4son-kernel.com/keys/http/archive-key.asc

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -110,7 +110,7 @@
     lineinfile:
       dest: /etc/hosts
       regexp: '^127\.0\.1\.1[ \t]+raspberrypi'
-      line: '127.0.1.1\t{{pwnagotchi.hostname}}'
+      line: "127.0.1.1\t{{pwnagotchi.hostname}}"
       state: present
     when: hostname.changed
 


### PR DESCRIPTION
- Fixes the i2c and spi configuration to allow papirus screens to work as expected.
  - It changed boot.txt with the proper configuration
  - Adds management to /etc/modules to add the i2c module

- Adds the package `fbi` to enable the frame buffer display functionality

- Adds idempontency check to ansible tasks (to help with development units)
  - avoids reinstalling packages already installed like tensorflow and opencv. It checks package existency and also version installed
  - avoids rebuilding packages already installed, if the git clone has no changes, it will not rebuild (papirus repos).
  - does not change the hostname, unless it's the default `raspberrypi` hostname

- fixes /etc/hosts
  - It changes the entry for 127.0.1.1 instead of 127.0.0.1 to be compatible with `raspi-config`

@dadav could you please review these changes?
the fact `ansible_hostname` cannot be used to check the current hostname, as we are running on a chroot, so we need to read the contents of /etc/hostname