### PR TITLE
Improve manual mode detection for RPi3-4

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -304,7 +304,8 @@
         # blink 10 times to signal ready state
         /usr/bin/bootblink 10 &
         # start a detached screen session with bettercap
-        if ifconfig | grep usb0 | grep RUNNING; then
+        # If USB-interface or eth0-interface(RPi3&4) is up, go to manual mode
+        if [[ ifconfig | grep usb0 | grep RUNNING ]] || [[ $(cat /sys/class/net/eth0/carrier) ]]; then
           # if override file exists, go into auto mode
           if [ -f /root/.pwnagotchi-auto ]; then
             rm /root/.pwnagotchi-auto
@@ -313,7 +314,13 @@
             /usr/local/bin/pwnagotchi --manual
           fi
         else
-          /usr/local/bin/pwnagotchi
+        # if override file exists, go into manual mode
+          if [ -f /root/.pwnagotchi-manual ]; then
+            rm /root/.pwnagotchi-manual
+            /usr/local/bin/pwnagotchi --manual
+          else  
+            /usr/local/bin/pwnagotchi
+          fi
         fi
 
   - name: create bettercap-launcher script
@@ -325,7 +332,7 @@
         # blink 10 times to signal ready state
         /usr/bin/bootblink 10 &
         /usr/bin/monstart
-        if ifconfig | grep usb0 | grep RUNNING; then
+        if [[ ifconfig | grep usb0 | grep RUNNING ]] || [[ $(cat /sys/class/net/eth0/carrier) ]]; then
           # if override file exists, go into auto mode
           if [ -f /root/.pwnagotchi-auto ]; then
             rm /root/.pwnagotchi-auto
@@ -334,7 +341,13 @@
             /usr/bin/bettercap -no-colors -caplet pwnagotchi-manual -iface mon0
           fi
         else
-          /usr/bin/bettercap -no-colors -caplet pwnagotchi-auto -iface mon0
+          # if override file exists, go into manual mode
+          if [ -f /root/.pwnagotchi-manual ]; then
+            rm /root/.pwnagotchi-manual
+            /usr/bin/bettercap -no-colors -caplet pwnagotchi-manual -iface mon0
+          else
+            /usr/bin/bettercap -no-colors -caplet pwnagotchi-auto -iface mon0
+          fi
         fi
 
   - name: create monstart script


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RPi3 and 4 does not have a USB data-interface so they have no way of start in manual mode.
This change makes pwnagotchi start in manual mode if a link is detected on the eth0-interface or if the file .pwnagotchi-manual is placed in /root/ (similar to the .pwnagotchi-auto file)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue here: https://github.com/evilsocket/pwnagotchi/issues/365
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NO
I only have access to RPi3 at the moment, needs to be verified on a RPi0W and maybe a RPi4.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
