### PR TITLE
Show information on failed backup on display

### DIFF
--- a/pwnagotchi/plugins/default/auto-backup.py
+++ b/pwnagotchi/plugins/default/auto-backup.py
@@ -57,9 +57,10 @@ def on_internet_available(agent):
                     raise OSError(f"Command failed (rc: {process.returncode})")
 
             logging.info("AUTO-BACKUP: backup done")
+            display.set('status', 'Backup done!')
+            display.update()
             STATUS.update()
         except OSError as os_e:
             logging.info(f"AUTO-BACKUP: Error: {os_e}")
-
-        display.set('status', 'Backup done!')
-        display.update()
+            display.set('status', 'Backup failed!')
+            display.update()


### PR DESCRIPTION
Currently it's not clear if the auto-backup fails without looking into the logs.

## Description
This change shows a warning on screen if the auto-backup failed (for whatever reason)

## How Has This Been Tested?
Testes on my PiZ in context of #391 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
