### PR TITLE
Added plugin PAW GPS

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -79,6 +79,10 @@ main:
         memtemp: # Display memory usage, cpu load and cpu temperature on screen
             enabled: false
             orientation: horizontal # horizontal/vertical
+        pawgps:
+            enabled: false
+            #The IP Address of your phone with Paw Server running, default (option is empty) is 192.168.44.1
+            ip: ''
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already

--- a/pwnagotchi/plugins/default/paw-gps.py
+++ b/pwnagotchi/plugins/default/paw-gps.py
@@ -1,0 +1,33 @@
+__author__ = 'leont'
+__version__ = '1.0.0'
+__name__ = 'pawgps'
+__license__ = 'GPL3'
+__description__ = 'Saves GPS coordinates whenever an handshake is captured. The GPS data is get from PAW on android '
+
+'''
+You need an bluetooth connection to your android phone which is running PAW server with the GPS "hack" from Systemic:
+https://raw.githubusercontent.com/systemik/pwnagotchi-bt-tether/master/GPS-via-PAW
+'''
+
+import logging
+import json
+import requests
+
+OPTIONS = dict()
+
+
+def on_loaded():
+    logging.info("PAW-GPS loaded")
+    if 'ip' not in OPTIONS or ('ip' in OPTIONS and OPTIONS['ip'] is None):
+       logging.info("PAW-GPS: No IP Address in the config file is defined, it uses the default (192.168.44.1)")
+
+def on_handshake(agent, filename, access_point, client_station):
+        if 'ip' not in OPTIONS or ('ip' in OPTIONS and OPTIONS['ip'] is None):
+            ip = "192.168.44.1"
+
+        gps = requests.get('http://' + ip + '/gps.xhtml')
+        gps_filename = filename.replace('.pcap', '.gps.json')
+
+        logging.info("saving GPS to %s (%s)" % (gps_filename, gps))
+        with open(gps_filename, 'w+t') as f:
+            f.write(gps.text)


### PR DESCRIPTION
## Description
I added the plugin paw-gps and added one option to the config file

The plugin saves every time a handshake is captured, the gps position from the smartphone over the paw server

## How Has This Been Tested?
I tested the plugin myself on a RPI Zero W with the Paw server running on my Sony Xperia with the bt-tether plugin

## Types of changes
New feature (non-breaking change which adds functionality)

