### PR TITLE
ui/web: Use nearest-neighbor scaling in UI img

### DIFF
--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -30,6 +30,9 @@ STYLE = """
     cursor: pointer;
     text-align: center;
 }
+img {
+    image-rendering: pixelated;
+}
 """
 
 SCRIPT = """


### PR DESCRIPTION
## Description
Changes web ui image scaling to use nearest-neighbor scaling instead of the browser default.

## Motivation and Context
The default on many devices scales the image in the webui badly, causing scaling artifacts and soft borders. NN scaling will display it the same as it does on the eink display itself.

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
https://github.com/evilsocket/pwnagotchi/issues/411

## How Has This Been Tested?
Open the Web UI and notice the image now scales correctly

![image](https://user-images.githubusercontent.com/8442384/67622058-8ec8bd00-f816-11e9-94c0-239a4a01c1cf.png)


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
