### PR TITLE
plugins/quickdic: Search subdirectories of `wordlist_folder`

### DIFF
--- a/pwnagotchi/plugins/default/quickdic.py
+++ b/pwnagotchi/plugins/default/quickdic.py
@@ -30,7 +30,7 @@ def on_handshake(agent, filename, access_point, client_station):
         logging.info("[quickdic] No handshake")
     else:
         logging.info("[quickdic] Handshake confirmed")
-        result2 = subprocess.run(('aircrack-ng -w `echo '+OPTIONS['wordlist_folder']+'*.txt | sed \'s/\ /,/g\'` -l '+filename+'.cracked -q -b '+result+' '+filename+' | grep KEY'),shell=True,stdout=subprocess.PIPE)
+        result2 = subprocess.run(('aircrack-ng -w `find '+OPTIONS['wordlist_folder']+' -name \'*.txt\' | tr -s $\'\n\' \',\' | rev | cut -c2- | rev` -l '+filename+'.cracked -q -b '+result+' '+filename+' | grep KEY'),shell=True,stdout=subprocess.PIPE)
         result2 = result2.stdout.decode('utf-8').strip()
         logging.info("[quickdic] "+result2)
         if result2 != "KEY NOT FOUND":


### PR DESCRIPTION
This allows to place wordlists in different subdirectories of `wordlist_folder` while still having them recognized by quickdic.py

## Description
Uses `find` instead of a simple glob to find all `.txt` files in `wordlist_folder` and its subdirectories

## Motivation and Context
This allows for sorted `wordlist_folders` instead of having all wordlists fly around in the same root directory.
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
https://github.com/evilsocket/pwnagotchi/issues/418

## How Has This Been Tested?
Ran the different implementations and compared the wordlists they find in the directory

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
