### PR TITLE
Back up plugin files and wordlists

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -29,12 +29,13 @@ main:
             enabled: false
             interval: 1 # every day
             files:
+                - /etc/pwnagotchi/
+                - /opt/wordlists/
                 - /root/brain.nn
                 - /root/brain.json
                 - /root/.api-report.json
                 - /root/handshakes/
                 - /root/peers/
-                - /etc/pwnagotchi/
                 - /var/log/pwnagotchi.log
             commands:
                 - 'tar czf /root/pwnagotchi-backup.tar.gz {files}'

--- a/pwnagotchi/plugins/default/onlinehashcrack.py
+++ b/pwnagotchi/plugins/default/onlinehashcrack.py
@@ -10,7 +10,7 @@ import requests
 from pwnagotchi.utils import StatusFile
 
 READY = False
-REPORT = StatusFile('/root/.ohc_uploads', data_format='json')
+REPORT = StatusFile('/etc/pwnagotchi/ohc_uploads.json', data_format='json')
 SKIP = list()
 OPTIONS = dict()
 

--- a/pwnagotchi/plugins/default/wigle.py
+++ b/pwnagotchi/plugins/default/wigle.py
@@ -14,7 +14,7 @@ import requests
 from pwnagotchi.utils import WifiInfo, FieldNotFoundError, extract_from_pcap, StatusFile
 
 READY = False
-REPORT = StatusFile('/root/.wigle_uploads', data_format='json')
+REPORT = StatusFile('/etc/pwnagotchi/wigle_uploads.json', data_format='json')
 SKIP = list()
 OPTIONS = dict()
 

--- a/pwnagotchi/plugins/default/wpa-sec.py
+++ b/pwnagotchi/plugins/default/wpa-sec.py
@@ -10,7 +10,7 @@ import requests
 from pwnagotchi.utils import StatusFile
 
 READY = False
-REPORT = StatusFile('/root/.wpa_sec_uploads', data_format='json')
+REPORT = StatusFile('/etc/pwnagotchi/wpa_sec_uploads.json', data_format='json')
 OPTIONS = dict()
 SKIP = list()
 
@@ -28,13 +28,13 @@ def on_loaded():
     if 'api_url' not in OPTIONS or ('api_url' in OPTIONS and OPTIONS['api_url'] is None):
         logging.error("WPA_SEC: API-URL isn't set. Can't upload, no endpoint configured.")
         return
-        
+
     READY = True
 
 
 def _upload_to_wpasec(path, timeout=30):
     """
-    Uploads the file to https://wpa-sec.stanev.org, or another endpoint. 
+    Uploads the file to https://wpa-sec.stanev.org, or another endpoint.
     """
     with open(path, 'rb') as file_to_upload:
         cookie = {'key': OPTIONS['api_key']}

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -6,12 +6,13 @@ UNIT_HOSTNAME=${1:-10.0.0.2}
 OUTPUT=${2:-pwnagotchi-backup.zip}
 # what to backup
 FILES_TO_BACKUP=(
-  /root/brain.nn
-  /root/brain.json
-  /root/.api-report.json
-  /root/handshakes
-  /root/peers
   /etc/pwnagotchi/
+  /opt/wordlists/
+  /root/.api-report.json
+  /root/brain.json
+  /root/brain.nn
+  /root/handshakes/
+  /root/peers/
   /var/log/pwnagotchi.log
 )
 


### PR DESCRIPTION
Fixes #403.

## Description

This PR backs up the following plugin data:
1. List of handshakes sent to OHC (`onlinehashcrack.py`).
2. List of handshakes sent to Wigle (`wigle.py`).
3. List of handshakes sent to Wpa-sec (`wpa-sec.py`).
4. Wordlists for dictionary lookup (`quickdic.py`).

Sent handshake lists are moved to `/etc/pwnagotchi`, making it a designated place for all configuration and status files that need to persist across updates and backup/restore cycles.

For wordlists, `/opt/wordlists` is added to the list of files to back up. It shouldn't contribute significantly to the backup size, as the optimal wordlist size for Pi Zero is just a few kilobytes.

## Motivation and Context

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

There's more details in #403. Alternative approaches would be:
1. Adding `/root` to the backup list. The downside is that there might be a lot of unrelated things in `/root`, especially in non-standard and manual Pwnagotchi installations.
2. Adding specific plugin files to the backup list. The downside is that every plugin will have to be added, and if people create custom plugins, they won't be backed up unless the script is modified as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
