### PR TITLE
Fix for #421 / Webhook missing positional argiment

### DIFF
--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -177,7 +177,7 @@ class Handler(BaseHTTPRequestHandler):
                 groups = matches.groups()
                 plugin_name = groups[0]
                 right_path = groups[1] if len(groups) == 2 else None
-                plugins.one(plugin_name, 'webhook', right_path)
+                plugins.one(plugin_name, 'webhook', self, right_path)
 
         else:
             self.send_response(404)


### PR DESCRIPTION
Missed giving the argument to actually be able to write the response.

## Description
Just added 'self' as argument

## Motivation and Context
Fixes #421 
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I called the example plugin webhook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
