### PR TITLE
plugins/AircrackOnly: Only parse pcap once and don't delete pcaps with more than one handshake

### DIFF
--- a/pwnagotchi/plugins/default/AircrackOnly.py
+++ b/pwnagotchi/plugins/default/AircrackOnly.py
@@ -13,32 +13,23 @@ import logging
 import subprocess
 import string
 import os
+import ast
 
 OPTIONS = dict()
 
 def on_loaded():
-    logging.info("aircrackonly plugin loaded")
+    logging.info("[AircrackOnly] plugin loaded")
 
 def on_handshake(agent, filename, access_point, client_station):
     display = agent._view
-    todelete = 0
 
-    result = subprocess.run(('/usr/bin/aircrack-ng '+ filename +' | grep "1 handshake" | awk \'{print $2}\''),shell=True, stdout=subprocess.PIPE)
-    result = result.stdout.decode('utf-8').translate({ord(c) :None for c in string.whitespace})
-    if result:
-        logging.info("[AircrackOnly] contains handshake")
+    result = ast.literal_eval(subprocess.run(('/usr/bin/aircrack-ng '+filename+' | gawk \'/[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}/ {printf "["} match($0, /([0-9]+) handshake/, hs) {printf hs[1] ","} /handshake)/ {printf "False"} /with PMKID/ {printf "True"} /[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}/ {print "]"}\''), shell=True, stdout=subprocess.PIPE).stdout.decode('utf-8'))
+    if result[0] > 0:
+        logging.info("[AircrackOnly] contains "+str(result[0])+" handshake(s)")
+    elif result[1]:
+        logging.info("[AircrackOnly] contains PMKID")
     else:
-        todetele = 1
-
-    if todelete == 0:
-        result = subprocess.run(('/usr/bin/aircrack-ng '+ filename +' | grep "PMKID" | awk \'{print $2}\''),shell=True, stdout=subprocess.PIPE)
-        result = result.stdout.decode('utf-8').translate({ord(c) :None for c in string.whitespace})
-        if result:
-            logging.info("[AircrackOnly] contains PMKID")
-        else:
-            todetele = 1
-
-    if todelete == 1:
+        logging.info("[AircrackOnly] contains nothing useful")
         os.remove(filename)
         set_text("uncrackable pcap")
         display.update(force=True)


### PR DESCRIPTION
## Description
This refactors AircrackOnly to:
- parse the pcap only once to increase efficiency
- not delete pcaps containing more than one handshake (just in case)
- log uncrackable pcaps to `logging.info`

## Motivation and Context
This simplifies and cleans up AircrackOnly a bunch, and stops it from starting up aircrack-ng twice to parse the same data - decreasing cpu time required.

## How Has This Been Tested?
I have tested this locally in a python session.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
