### PR TITLE
Fix the AircrackOnly plugin

### DIFF
--- a/pwnagotchi/plugins/default/AircrackOnly.py
+++ b/pwnagotchi/plugins/default/AircrackOnly.py
@@ -1,5 +1,5 @@
 __author__ = 'pwnagotchi [at] rossmarks [dot] uk'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __name__ = 'AircrackOnly'
 __license__ = 'GPL3'
 __description__ = 'confirm pcap contains handshake/PMKID or delete it'
@@ -28,7 +28,7 @@ def on_handshake(agent, filename, access_point, client_station):
     if result:
         logging.info("[AircrackOnly] contains handshake")
     else:
-        todetele = 1
+        todelete = 1
 
     if todelete == 0:
         result = subprocess.run(('/usr/bin/aircrack-ng '+ filename +' | grep "PMKID" | awk \'{print $2}\''),shell=True, stdout=subprocess.PIPE)
@@ -36,11 +36,11 @@ def on_handshake(agent, filename, access_point, client_station):
         if result:
             logging.info("[AircrackOnly] contains PMKID")
         else:
-            todetele = 1
+            todelete = 1
 
     if todelete == 1:
         os.remove(filename)
-        set_text("uncrackable pcap")
+        set_text("Removed an uncrackable pcap")
         display.update(force=True)
 
 text_to_set = "";


### PR DESCRIPTION
Fixes #398.

AircrackOnly plugin wasn't working because of a typo: marking files for deletion referenced a wrong variable.

On a related note, it might be a good idea to make this plugin part of the core functionality, as it would reduce the clutter. On the other hand, it'll introduce the `aircrack-ng` dependency. What do you think?