### PR TITLE
InkyPHAT opt-in for fast refresh

### DIFF
--- a/pwnagotchi/ui/hw/inky.py
+++ b/pwnagotchi/ui/hw/inky.py
@@ -33,15 +33,25 @@ class Inky(DisplayImpl):
 
     def initialize(self):
         logging.info("initializing inky display")
-        from pwnagotchi.ui.hw.libs.inkyphat.inkyphatfast import InkyPHATFast
-        self._display = InkyPHATFast(self.config['color'])
-        self._display.set_border(InkyPHATFast.BLACK)
+
+        if self.config['color'] == 'fastAndFurious':
+            logging.info("Initializing Inky in 2-color FAST MODE")
+            logging.info("THIS MAY BE POTENTIALLY DANGEROUS. NO WARRANTY IS PROVIDED")
+            logging.info("USE THIS DISPLAY IN THIS MODE AT YOUR OWN RISK")
+
+            from pwnagotchi.ui.hw.libs.inkyphat.inkyphatfast import InkyPHATFast
+            self._display = InkyPHATFast('black')
+            self._display.set_border(InkyPHATFast.BLACK)
+        else:
+            from inky import InkyPHAT
+            self._display = InkyPHAT(self.config['color'])
+            self._display.set_border(InkyPHAT.BLACK)
 
     def render(self, canvas):
-        if self.config['color'] != 'mono':
-            display_colors = 3
-        else:
+        if self.config['color'] == 'black' or self.config['color'] == 'fastAndFurious':
             display_colors = 2
+        else:
+            display_colors = 3
 
         img_buffer = canvas.convert('RGB').convert('P', palette=1, colors=display_colors)
         if self.config['color'] == 'red':


### PR DESCRIPTION
Made a specific color option called 'fastAndFurious' based on similar work in https://github.com/evilsocket/pwnagotchi/pull/428 - this is an emphatic opt-in to use the fast refresh that avoids the black flash, and updates the timings.

## Description
InkyPHATFast is a subclass of InkyPHAT so all functionality is matched. When the inky is initialising, if the color 'fastAndFurious' is selected, the InkyPHATFast library is used.  A warning is generated via logging Info.

If any other color is used, the standard Inky library is imported.

When rendering, if Black or 'fastAndFurious' are detected the default is 2 colors, otherwise it is 3 colors.

## Motivation and Context
Resolves several requests to have the original Inky rendering as an option. Discussion in Slack regarding an instance of burn-in prompted an enhancement request (https://github.com/evilsocket/pwnagotchi/issues/437) and there was a discussion at the end of the original implementation pull request (https://github.com/evilsocket/pwnagotchi/pull/276#issuecomment-546635805)

- [x] I have raised an issue to propose this change (https://github.com/evilsocket/pwnagotchi/issues/437)


## How Has This Been Tested?
Tested on a 2 color and 3 color display:
Tested with the following colors:
Yellow: slow refresh
Black: slow refresh
fastAndFurious: faster refresh + warning generated in logs.

Code change is specific to the inky area, in initialization and rendering.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

If you wish documentation to be added for the 'special color' let me know and I'll raise a documentation change.
