### PR TITLE
Waveshare 1.54 inch screen - config possibility in defaults.yml

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -204,7 +204,7 @@ ui:
     display:
         enabled: true
         rotation: 180
-        # Possible options inkyphat/inky, papirus/papi, waveshare_1/ws_1 or waveshare_2/ws_2, oledhat, lcdhat, waveshare27inch, dfrobot/df
+        # Possible options inkyphat/inky, papirus/papi, waveshare_1/ws_1 or waveshare_2/ws_2, oledhat, lcdhat, waveshare154inch, waveshare27inch, dfrobot/df
         type: 'waveshare_2'
         # Possible options red/yellow/black (black used for monocromatic displays)
         # Waveshare tri-color 2.13in display can be over-driven with color set as 'fastAndFurious'


### PR DESCRIPTION
## Description

Adding info about display's config option to the comment in `defaults.yml`

## Motivation and Context
- For the sake of completeness the comment with the existing screens should be maintained to reflect the supported screens. 
- [x] I have raised an issue to propose this change (#444 )

## How Has This Been Tested?
No test needed, there is only a change inside of a comment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
