### PR TITLE
Re-Add Network related files to backup

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,7 +17,7 @@ FILES_TO_BACKUP=(
   /etc/pwnagotchi/
   /var/log/pwnagotchi.log
   /home/pi/.bashrc
-  /etc/network/interfaced.d/usb0
+  /etc/network/interfaced.d/usb0-cfg
   /etc/hostname
   /etc/hosts
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,7 +17,7 @@ FILES_TO_BACKUP=(
   /etc/pwnagotchi/
   /var/log/pwnagotchi.log
   /home/pi/.bashrc
-  /etc/network/interfaced.d/usb0-cfg
+  /etc/network/interfaces.d/usb0-cfg
   /etc/hostname
   /etc/hosts
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,6 +17,11 @@ FILES_TO_BACKUP=(
   /etc/pwnagotchi/
   /var/log/pwnagotchi.log
   /home/pi/.bashrc
+  /etc/network/interfaced.d/usb0
+  /etc/hostname
+  /etc/hosts
+
+  
 )
 
 ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {


### PR DESCRIPTION
## Description
I'm not quite sure, why those files have been removed in this commit:
https://github.com/evilsocket/pwnagotchi/commit/c954bf8ffa424b7cd9ec3aadc9d15f0b2f2e9eb9#diff-179da8459e84bc41a473e2921dce8b57

Given that you'd like to restore the unit without the need to change anything afterwards, I'd like to see those files included in the backup.

## How Has This Been Tested?
Tested with latest RC

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
