### PR TITLE
Fix lcdhat _display.clear()

### DIFF
--- a/pwnagotchi/ui/hw/lcdhat.py
+++ b/pwnagotchi/ui/hw/lcdhat.py
@@ -37,7 +37,7 @@ class LcdHat(DisplayImpl):
         from pwnagotchi.ui.hw.libs.waveshare.lcdhat.epd import EPD
         self._display = EPD()
         self._display.init()
-        self._display.Clear()
+        self._display.clear()
 
     def render(self, canvas):
         self._display.display(canvas)


### PR DESCRIPTION
There is a typo (uppercase / lowercase) which prevents the lcdhat display from initializing.
It was introduced with this change: https://github.com/evilsocket/pwnagotchi/commit/277906a6738553263db0174d003dd1367137423e

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
