### PR TITLE
check zip is installed first before running backup

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -19,6 +19,11 @@ FILES_TO_BACKUP=(
   /home/pi/.bashrc
 )
 
+if ! type "zip" >/dev/null 2>&1; then
+  echo "This script requires zip, please resolve and try again"
+  exit 1
+fi
+
 ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1


### PR DESCRIPTION
Signed-off-by: Ciara Brennan <ciara.brennan@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Added a check to see if zip is installed before proceeding, and exit if user needs to install zip
## Description
<!--- Describe your changes in detail -->
Needed to add this as apparently zip doesn't come as default in my  Ubuntu WSL. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required]
https://github.com/evilsocket/pwnagotchi/issues/455

(https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested in Ubuntu WSL by running ./backup.sh before and after the change, installed zip, re-run script and confirmed backup.sh script outputs the expected zip file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
