### PR TITLE
Fix eth0 connection check for MANU mode

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -304,7 +304,7 @@
         # blink 10 times to signal ready state
         /usr/bin/bootblink 10 &
         # start a detached screen session with bettercap
-        if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ $(cat /sys/class/net/eth0/carrier) ]]; then
+        if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ !$(grep '1' /sys/class/net/eth0/carrier) ]]; then
           # if override file exists, go into auto mode
           if [ -f /root/.pwnagotchi-auto ]; then
             rm /root/.pwnagotchi-auto
@@ -323,7 +323,7 @@
       content: |
         #!/usr/bin/env bash
         /usr/bin/monstart
-        if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ $(cat /sys/class/net/eth0/carrier) ]]; then
+        if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ !$(grep '1' /sys/class/net/eth0/carrier) ]]; then
           # if override file exists, go into auto mode
           if [ -f /root/.pwnagotchi-auto ]; then
             /usr/bin/bettercap -no-colors -caplet pwnagotchi-auto -iface mon0


### PR DESCRIPTION
Issue #460 - Originally noted by @ZeroCool-Dade
https://github.com/evilsocket/pwnagotchi/commit/a78a4b0b3e5cfbdfea481e140e6c02e0bdb1f72d#commitcomment-35683998

Signed-off-by: Lorenzo Milesi <io@maxxer.it>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix eth0 check, as it's currently detected as always up thus starting pwnagotchi in MANU mode on Raspberries with eth0 port

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I've tried starting and restarting pwnagotchi with the fix applied and no ethernet cable connected it starts in AUTO. With cable connected it will start in MANU.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
