### PR TITLE
Added exception handling to config.yml parsing

### DIFF
--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -65,12 +65,16 @@ def load_config(args):
         config = yaml.safe_load(fp)
 
     # load the user config
-    if os.path.exists(args.user_config):
-        with open(args.user_config) as fp:
-            user_config = yaml.safe_load(fp)
-            # if the file is empty, safe_load will return None and merge_config will boom.
-            if user_config:
-                config = merge_config(user_config, config)
+    try:
+        if os.path.exists(args.user_config):
+            with open(args.user_config) as fp:
+                user_config = yaml.safe_load(fp)
+                # if the file is empty, safe_load will return None and merge_config will boom.
+                if user_config:
+                    config = merge_config(user_config, config)
+    except yaml.YAMLError as ex:
+        print("There was an error processing the configuration file:\n%s " % ex)
+        exit(1)
 
     # the very first step is to normalize the display name so we don't need dozens of if/elif around
     if config['ui']['display']['type'] in ('inky', 'inkyphat'):

--- a/scripts/preview.py
+++ b/scripts/preview.py
@@ -87,8 +87,7 @@ def append_images(images, horizontal=True, xmargin=0, ymargin=0):
 def main():
     parser = argparse.ArgumentParser(description="This program emulates\
                                      the pwnagotchi display")
-    parser.add_argument('--displays', help="Which displays to use.", nargs="+",
-                        default="waveshare_2")
+    parser.add_argument('--displays', help="Which displays to use.", nargs="+", default=["waveshare_2"])
     parser.add_argument('--lang', help="Language to use",
                         default="en")
     parser.add_argument('--output', help="Path to output image (PNG)", default="preview.png")


### PR DESCRIPTION
Wrapped the config.yml loading with a try/except and reports back smaller exception details than  traceback.

## Description
The section marked 'load a user config' now has an exception handler specifically for the YAMLError exception. Other issues will generate a full traceback but the exception handling could be expanded in future.

Typical output on an invalid config.yml:
```
There was an error processing the configuration file:
while parsing a block mapping
  in "/etc/pwnagotchi/config.yml", line 18, column 7
expected <block end>, but found '<scalar>'
  in "/etc/pwnagotchi/config.yml", line 22, column 18 

```

A valid configuration file allows program to run without exception being raised.

## Motivation and Context
There were several issues raised in Slack where new users did not know they were getting configuration errors. This is more explicit and helps fault tracking both by the user and in Slack.

- [x] I have raised an issue to propose this change https://github.com/evilsocket/pwnagotchi/issues/464


## How Has This Been Tested?
Tried a number of different faults in YML, and each generated similar output to above.
Issues on merging are *not* considered at this point in time.

Tested on RPI0, and on VM running Mint Linux


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`


## Addendum:
This also includes a fix for the --displays issue in preview.py that was supposed to be part of a separate PR. Let me know if you'd prefer it to be separate. It's gone through all the checks. If --displays is supposed to allow multiple displays it should be an array, not string. When going through the displays iterator it was going character by character on the string, rather than looking at a string array.