### PR TITLE
fix: don't attempt to parse/upload pcaps with malformed filenames

### DIFF
--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -9,6 +9,7 @@ import os
 import logging
 import time
 import glob
+import re
 
 import pwnagotchi.grid as grid
 from pwnagotchi.utils import StatusFile, WifiInfo, extract_from_pcap
@@ -35,6 +36,10 @@ def parse_pcap(filename):
     else:
         # /root/handshakes/BSSID.pcap
         essid, bssid = '', net_id
+
+    mac_re = re.compile('[0-9a-fA-F]{12}')
+    if not mac_re.match(bssid):
+        return '', ''
 
     it = iter(bssid)
     bssid = ':'.join([a + b for a, b in zip(it, it)])


### PR DESCRIPTION
Signed-off-by: Jeremy O'Brien <neutral@fastmail.com>

Currently the grid plugin will blindly attempt to parse the filenames of any pcaps found in /root/handshakes. If the pcap doesn't match our specific expected filename format, we should probably skip said pcap. This change does just that.

## Description
Added a check to ensure that the parsed MAC of a given pcap filename actually looks like a MAC before we hit the public grid API.

## Motivation and Context
Gets rid of the following exception when a randomly named pcap ends up in /root/handshakes:
```
[2019-10-30 19:26:16,210] [INFO] grid: 1 new networks to report
[2019-10-30 19:26:16,292] [INFO] grid: parsing /root/handshakes/aiesrnt.pcap ...
[2019-10-30 19:26:16,689] [ERROR] grid: Not a supported capture file
[2019-10-30 19:26:17,190] [ERROR] error while reporting ap (ai:es:rn)
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/pwnagotchi/grid.py", line 86, in report_ap
    'bssid': bssid,
  File "/usr/local/lib/python3.7/dist-packages/pwnagotchi/grid.py", line 30, in call
    raise Exception("(status %d) %s" % (r.status_code, r.text))
Exception: (status 422) {"error":"422 "}
```

## How Has This Been Tested?
Added a garbage named pcap file to /root/handshakes and observed the expected behavior in pwnagotchi.log:
```
[2019-10-30 19:35:25,294] [INFO] grid: 1 new networks to report
[2019-10-30 19:35:25,340] [INFO] grid: parsing /root/handshakes/aiesrnt.pcap ...
[2019-10-30 19:35:25,353] [WARNING] no bssid found?!
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
