### PR TITLE
Change the ordering of the provisioners of packer

### DIFF
--- a/builder/pwnagotchi.json
+++ b/builder/pwnagotchi.json
@@ -20,17 +20,6 @@
       ]
     },
     {
-      "type": "ansible-local",
-      "playbook_file": "pwnagotchi.yml",
-      "command": "ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 PWN_VERSION={{user `pwn_version`}} PWN_HOSTNAME={{user `pwn_hostname`}} ansible-playbook"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "sed -i 's/^#\\(.+\\)/\\1/g' /etc/ld.so.preload"
-      ]
-    },
-    {
       "type": "file",
       "source": "data/usr/bin/bettercap-launcher",
       "destination": "/usr/bin/bettercap-launcher"
@@ -69,6 +58,17 @@
       "type": "file",
       "source": "data/etc/systemd/system/bettercap.service",
       "destination": "/etc/systemd/system/bettercap.service"
+    },
+    {
+      "type": "ansible-local",
+      "playbook_file": "pwnagotchi.yml",
+      "command": "ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 PWN_VERSION={{user `pwn_version`}} PWN_HOSTNAME={{user `pwn_hostname`}} ansible-playbook"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sed -i 's/^#\\(.+\\)/\\1/g' /etc/ld.so.preload"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fix the ordering of the provisioners, because the ansible-playbook is activating the service-files, so they should be there before ansible runs.