### PR TITLE
fix: simplify and fix pwnagotchi-launcher logic

### DIFF
--- a/builder/data/usr/bin/pwnagotchi-launcher
+++ b/builder/data/usr/bin/pwnagotchi-launcher
@@ -2,15 +2,15 @@
 # blink 10 times to signal ready state
 /usr/bin/bootblink 10 &
 
-# if usb0 or eth0 are up
-if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ !$(grep '1' /sys/class/net/eth0/carrier) ]]; then
-  # if override file exists, go into auto mode
-  if [ -f /root/.pwnagotchi-auto ]; then
-    rm /root/.pwnagotchi-auto
-    /usr/local/bin/pwnagotchi
-  else
-    /usr/local/bin/pwnagotchi --manual
-  fi
+# if override file exists, go into auto mode
+if [ -f /root/.pwnagotchi-auto ]; then
+  rm /root/.pwnagotchi-auto
+  /usr/local/bin/pwnagotchi
+  exit
+fi
+
+if [[ $(ifconfig | grep usb0 | grep RUNNING) ]] || [[ $(grep 1 /sys/class/net/eth0/carrier) ]]; then
+  /usr/local/bin/pwnagotchi --manual
 else
   /usr/local/bin/pwnagotchi
 fi


### PR DESCRIPTION
Signed-off-by: Jeremy O'Brien <neutral@fastmail.com>

Self-explanatory

## Description
It appears as though the launcher is broken right now. pi0 is always booting into manual mode regardless of network state.

## Motivation and Context
It looks like the line that checks for a carrier on eth0 (for pi{1,2,3,4}) will evaluate to the same result as detecting a carrier when the interface doesn't exist (like on the pi0). By inverting the logic, we enter auto mode in both the case where the interface is present without a carrier (grep failure) and when the interface isn't present at all (grep failure).

I also simplified the logic flow a little to avoid nested if's.

- [x] maxxer has raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
https://github.com/evilsocket/pwnagotchi/issues/473

## How Has This Been Tested?
maxxer on slack tested by observing that the pi0 always boots into manual mode without this change, but properly boots into auto mode when appropriate when this change is applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
