### PR TITLE
Change memory splitting to have more memory available

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -13,6 +13,7 @@
         - "dtparam=spi=on"
         - "dtparam=i2c_arm=on"
         - "dtparam=i2c1=on"
+        - "gpu_mem=16"
       modules:
         - "i2c-dev"
     services:


### PR DESCRIPTION
As most users won't use a big GUI, it should be sufficient to have 16MB assigned to the GPU and have some more for the system.

## Description
By default 64MB RAM are assigned to the GPU, this can be changed in `config.txt` to 16MB

## Motivation and Context
You get more available RAM which is always nice ...

## How Has This Been Tested?
set the value on my pi

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
