### PR TITLE
enhancement: Improve the backup script

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -3,7 +3,7 @@
 # name of the ethernet gadget interface on the host
 UNIT_HOSTNAME=${1:-10.0.0.2}
 # output backup zip file
-OUTPUT=${2:-pwnagotchi-backup.zip}
+OUTPUT=${2:-pwnagotchi-backup.tgz}
 # username to use for ssh
 USERNAME=${3:-pi}
 # what to backup
@@ -19,38 +19,10 @@ FILES_TO_BACKUP=(
   /home/pi/.bashrc
 )
 
-if ! type "zip" >/dev/null 2>&1; then
-  echo "This script requires zip, please resolve and try again"
-  exit 1
-fi
-
 ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1
 }
 
 echo "@ backing up $UNIT_HOSTNAME to $OUTPUT ..."
-
-ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo rm -rf /tmp/backup && sudo rm -rf /tmp/backup.zip" > /dev/null
-
-for file in "${FILES_TO_BACKUP[@]}"; do
-  dir=$(dirname "$file")
-
-  echo "@ copying $file to /tmp/backup$dir"
-
-  ssh "${USERNAME}@${UNIT_HOSTNAME}" "mkdir -p /tmp/backup${dir}" > /dev/null
-  ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo cp -r ${file} /tmp/backup${dir}" > /dev/null
-done
-
-ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo chown ${USERNAME}:${USERNAME} -R /tmp/backup" > /dev/null
-
-echo "@ pulling from $UNIT_HOSTNAME ..."
-
-rm -rf /tmp/backup
-scp -rC "${USERNAME}@${UNIT_HOSTNAME}":/tmp/backup /tmp/
-
-echo "@ compressing ..."
-
-zip -r -9 -q "$OUTPUT" /tmp/backup
-rm -rf /tmp/backup
-
+ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo tar cv ${FILES_TO_BACKUP[@]}" | gzip -9 > "$OUTPUT"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# name of the ethernet gadget interface on the host
+UNIT_HOSTNAME=${1:-10.0.0.2}
+# output backup zip file
+BACKUP=${2:-pwnagotchi-backup.tgz}
+# username to use for ssh
+USERNAME=${3:-pi}
+
+ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
+  echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
+  exit 1
+}
+
+echo "@ restoring $BACKUP to $UNIT_HOSTNAME ..."
+cat ${BACKUP} | ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo tar xzv -C /"


### PR DESCRIPTION
- Significantly decrease time it takes to save a backup
- Remove host dependency on 'zip' binary
- Preserve file attributes on backed-up files
- Avoid copying files on the pi itself to /tmp

Signed-off-by: Jeremy O'Brien <neutral@fastmail.com>

## Description
The backup script takes a long time to complete and puts a non-trivial amount of overhead on the pi during this time. By doing a minimum amount of work on the pi (creating an uncompressed tar of the relevant files to back up, sent through a pipe), the pi can get its portion of the backup task done very quickly. If the only purpose of taking a backup is to then later restore said backup, it shouldn't matter what format we keep the backup in, as long as we provide a way to restore the backup (which is included in the new `restore.sh` file).

The dependencies on the host with this change are:
`ssh`
`cat`
and a shell that can utilize the pipe (|) operator.

Here is the speed comparison:

old:
```
real	1m1.244s
user	0m1.797s
sys	0m0.653s
```

new:
```
real	0m7.951s
user	0m3.167s
sys	0m0.279s
```

## Motivation and Context
I want the backup script to be faster and put less strain on the pi. :)

## How Has This Been Tested?
Ran the backup script and verified the contents of the resulting archive.
Ran the restore script and verified the correct contents restored to the pi.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
