### PR TITLE
Bug Fix on AircrackOnly.py plugin

### DIFF
--- a/pwnagotchi/plugins/default/AircrackOnly.py
+++ b/pwnagotchi/plugins/default/AircrackOnly.py
@@ -27,16 +27,16 @@ class AircrackOnly(plugins.Plugin):
     def on_handshake(self, agent, filename, access_point, client_station):
         display = agent._view
         todelete = 0
+        handshakeFound = 0
 
         result = subprocess.run(('/usr/bin/aircrack-ng ' + filename + ' | grep "1 handshake" | awk \'{print $2}\''),
                                 shell=True, stdout=subprocess.PIPE)
         result = result.stdout.decode('utf-8').translate({ord(c): None for c in string.whitespace})
         if result:
+            handshakeFound = 1
             logging.info("[AircrackOnly] contains handshake")
-        else:
-            todelete = 1
 
-        if todelete == 0:
+        if handshakeFound == 0:
             result = subprocess.run(('/usr/bin/aircrack-ng ' + filename + ' | grep "PMKID" | awk \'{print $2}\''),
                                     shell=True, stdout=subprocess.PIPE)
             result = result.stdout.decode('utf-8').translate({ord(c): None for c in string.whitespace})


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The code will always delete the pcap file regardless of if there is a PMKID or Handshake due to the structure of the if statements. Added a new variable handshakeFound that will allow the file not to be deleted if there is a handshake and also it will scan for PMKID only if no handshake is found... If no handshake is found and no PMKID, only then the file is marked as to be deleted

## Motivation and Context

<!--- If it fixes an open issue, please link to the issue here. -->
- [ x ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

https://github.com/evilsocket/pwnagotchi/issues/506

## How Has This Been Tested?
Not tested it yet 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
