### PR TITLE
Added "Reboot into AUTO mode" button in web ui

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -112,3 +112,14 @@ def reboot():
     logging.warning("rebooting ...")
     os.system("sync")
     os.system("shutdown -r now")
+
+
+def reboot_into_auto():
+    logging.warning("rebooting into AUTO mode ...")
+    if view.ROOT:
+        view.ROOT.on_reboot()
+        # give it some time to refresh the ui
+        time.sleep(10)
+    os.system("touch /root/.pwnagotchi-auto")
+    os.system("sync")
+    os.system("shutdown -r now")

--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -52,8 +52,11 @@ INDEX = """<html>
         <img src="/ui" id="ui" style="width:100%%"/>
         <br/>
         <hr/>
-        <form method="POST" action="/shutdown" onsubmit="return confirm('This will halt the unit, continue?');">
-            <input type="submit" class="block" value="Shutdown"/>
+        <form style="display:inline;" method="POST" action="/shutdown" onsubmit="return confirm('This will halt the unit, continue?');">
+            <input style="display:inline;" type="submit" class="block" value="Shutdown"/>
+        </form>
+        <form style="display:inline;" method="POST" action="/reboot_into_auto" onsubmit="return confirm('This will reboot the unit into AUTO mode, continue?');">
+            <input style="display:inline;" type="submit" class="block" value="Reboot into AUTO mode"/>
         </form>
     </div>
 
@@ -73,6 +76,17 @@ SHUTDOWN = """<html>
   </body>
 </html>"""
 
+REBOOT_INTO_AUTO = """<html>
+  <head>
+      <title>%s</title>
+      <style>""" + STYLE + """</style>
+  </head>
+  <body>
+    <div style="position: absolute; top:0; left:0; width:100%%;">
+        Rebooting into AUTO mode ...
+    </div>
+  </body>
+</html>"""
 
 class Handler(BaseHTTPRequestHandler):
     AllowedOrigin = None  # CORS headers are not sent
@@ -115,6 +129,11 @@ class Handler(BaseHTTPRequestHandler):
     def _shutdown(self):
         self._html(SHUTDOWN % pwnagotchi.name())
         pwnagotchi.shutdown()
+
+    # serve a message and reboot the unit into auto mode
+    def _reboot(self):
+        self._html(REBOOT % pwnagotchi.name())
+        pwnagotchi.reboot_into_auto()
 
     # serve the PNG file with the display image
     def _image(self):


### PR DESCRIPTION
As requested in issue #502 I've added in the web UI a button that reboots the pwnagotchi into AUTO mode.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/evilsocket/pwnagotchi/issues/502


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my pwnagotchi and everything seems to run just fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
