### PR TITLE
fix: use a css class for the pixelated property, since apparently this still isn't standardized among different browsers

### DIFF
--- a/pwnagotchi/ui/web.py
+++ b/pwnagotchi/ui/web.py
@@ -30,6 +30,16 @@ STYLE = """
     cursor: pointer;
     text-align: center;
 }
+.pixelated {
+  image-rendering:optimizeSpeed;             /* Legal fallback */
+  image-rendering:-moz-crisp-edges;          /* Firefox        */
+  image-rendering:-o-crisp-edges;            /* Opera          */
+  image-rendering:-webkit-optimize-contrast; /* Safari         */
+  image-rendering:optimize-contrast;         /* CSS3 Proposed  */
+  image-rendering:crisp-edges;               /* CSS4 Proposed  */
+  image-rendering:pixelated;                 /* CSS4 Proposed  */
+  -ms-interpolation-mode:nearest-neighbor;   /* IE8+           */
+}
 """
 
 SCRIPT = """
@@ -48,8 +58,8 @@ INDEX = """<html>
       <style>""" + STYLE + """</style>
   </head>
   <body>
-    <div style="position: absolute; top:0; left:0; width:100%%;">
-        <img src="/ui" id="ui" style="width:100%%;image-rendering: pixelated;"/>
+    <div style="position: absolute; top:0; left:0; width:100%%;" class="pixelated">
+        <img src="/ui" id="ui" style="width:100%%;"/>
         <br/>
         <hr/>
         <form style="display:inline;" method="POST" action="/shutdown" onsubmit="return confirm('This will halt the unit, continue?');">


### PR DESCRIPTION

Signed-off-by: Jeremy O'Brien <neutral@fastmail.com>

## Description
shotgunned the various style properties for inducing pixelated images in most "mainstream" browsers.

## Motivation and Context
Make pwnagotchi face not blurry

## How Has This Been Tested?
Verified pixelated image shows in Firefox 70 and Chrome 78

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
