### PR TITLE
Add max_tries param

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -28,6 +28,7 @@ main:
         auto-backup:
             enabled: false
             interval: 1 # every day
+            max_tries: 0 # 0=infinity
             files:
                 - /root/brain.nn
                 - /root/brain.json


### PR DESCRIPTION
Added a "max_tries" parameter to the auto-backup plugin. If e.g. sshd isn't running on your backup host, the plugin would try it again and again. With this parameter you can prevent that.