### PR TITLE
#523: Add some styling to webui

### DIFF
--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -42,7 +42,7 @@ form {
     max-width: 100vw;
     height: 100%;
     object-fit: contain;
-    object-position: 0 0;
+    object-position: 50% 0;
 }
 
 .buttons-wrapper {

--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -1,42 +1,67 @@
-.block {
-    -webkit-appearance: button;
-    -moz-appearance: button;
-    appearance: button;
-
-    display: block;
-    cursor: pointer;
-    text-align: center;
+form {
+    margin-block-end: 0;
 }
 
-img#ui {
-    width:100%;
-}
 
-.full {
+.content {
     position: absolute;
-    top:0;
-    left:0;
-    width:100%;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
+/**
+ * make sure image is displayed without any blur
+ */
 .pixelated {
-  image-rendering:optimizeSpeed;             /* Legal fallback */
-  image-rendering:-moz-crisp-edges;          /* Firefox        */
-  image-rendering:-o-crisp-edges;            /* Opera          */
-  image-rendering:-webkit-optimize-contrast; /* Safari         */
-  image-rendering:optimize-contrast;         /* CSS3 Proposed  */
-  image-rendering:crisp-edges;               /* CSS4 Proposed  */
-  image-rendering:pixelated;                 /* CSS4 Proposed  */
-  -ms-interpolation-mode:nearest-neighbor;   /* IE8+           */
+    image-rendering: optimizeSpeed; /* Legal fallback */
+    image-rendering: -moz-crisp-edges; /* Firefox        */
+    image-rendering: -o-crisp-edges; /* Opera          */
+    image-rendering: -webkit-optimize-contrast; /* Safari         */
+    image-rendering: optimize-contrast; /* CSS3 Proposed  */
+    image-rendering: crisp-edges; /* CSS4 Proposed  */
+    image-rendering: pixelated; /* CSS4 Proposed  */
+    -ms-interpolation-mode: nearest-neighbor; /* IE8+           */
 }
 
-form.action {
-    display:inline;
+.image-wrapper {
+    flex: 1;
+    position: relative;
+}
+
+.ui-image {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    max-width: 100vw;
+    height: 100%;
+    object-fit: contain;
+    object-position: 0 0;
+}
+
+.buttons-wrapper {
+    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0 16px;
+}
+
+.button {
+    border: 1px solid black;
+    border-radius: 4px;
+    font-size: 2em;
+    background: #f8b506;
+    margin: 16px;
 }
 
 div.status {
     position: absolute;
-    top:0;
-    left:0;
-    width:100%;
+    top: 0;
+    left: 0;
+    width: 100%;
 }

--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -9,6 +9,7 @@ form {
     left: 0;
     width: 100vw;
     height: 100vh;
+    height: calc(var(--vh, 1vh) * 100);
     display: flex;
     flex-direction: column;
 }

--- a/pwnagotchi/ui/web/static/js/viewportHeight.js
+++ b/pwnagotchi/ui/web/static/js/viewportHeight.js
@@ -1,0 +1,17 @@
+/* https://css-tricks.com/the-trick-to-viewport-units-on-mobile/*/
+
+var lastViewportHeight;
+
+function updateViewportSize() {
+  // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
+  var vh = window.innerHeight * 0.01;
+  if (!lastViewportHeight || lastViewportHeight !== vh) {
+    // Then we set the value in the --vh custom property to the root of the document
+    document.documentElement.style.setProperty("--vh", vh + "px");
+    lastViewportHeight = vh;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  updateViewportSize();
+});

--- a/pwnagotchi/ui/web/templates/index.html
+++ b/pwnagotchi/ui/web/templates/index.html
@@ -1,26 +1,27 @@
 <html>
 <head>
-    <title>{{ title }}</title>
-    <link rel="stylesheet" type="text/css" href="/css/style.css"/>
+  <title>{{ title }}</title>
+  <link rel="stylesheet" type="text/css" href="/css/style.css"/>
 </head>
 <body>
-<div class="full pixelated">
-    <img src="/ui" id="ui"/>
-    <br/>
-    <hr/>
-
+<div class="content">
+  <div class="image-wrapper">
+    <img class="ui-image pixelated" src="/ui" id="ui"/>
+  </div>
+  <div class="buttons-wrapper">
     <form class="action" method="POST" action="/shutdown"
           onsubmit="return confirm('This will halt the unit, continue?');">
-        <input style="display:inline;" type="submit" class="block" value="Shutdown"/>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <input type="submit" class="button" value="Shutdown"/>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
 
     <form class="action" method="POST" action="/restart"
           onsubmit="return confirm('This will restart the service in {{ other_mode }} mode, continue?');">
-        <input style="display:inline;" type="submit" class="block" value="Restart in {{ other_mode }} mode"/>
-        <input type="hidden" name="mode" value="{{ other_mode }}"/>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <input type="submit" class="button" value="Restart in {{ other_mode }} mode"/>
+      <input type="hidden" name="mode" value="{{ other_mode }}"/>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
+  </div>
 </div>
 
 <script type="text/javascript" src="/js/refresh.js"></script>

--- a/pwnagotchi/ui/web/templates/index.html
+++ b/pwnagotchi/ui/web/templates/index.html
@@ -25,6 +25,7 @@
 </div>
 
 <script type="text/javascript" src="/js/refresh.js"></script>
+<script type="text/javascript" src="/js/refresh.js"></script>
 
 </body>
 </html>

--- a/pwnagotchi/ui/web/templates/index.html
+++ b/pwnagotchi/ui/web/templates/index.html
@@ -25,7 +25,7 @@
 </div>
 
 <script type="text/javascript" src="/js/refresh.js"></script>
-<script type="text/javascript" src="/js/refresh.js"></script>
+<script type="text/javascript" src="/js/viewportHeight.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
So, let's try again for #535 ... 

<img width="1502" alt="Screenshot 2019-11-05 at 23 19 49" src="https://user-images.githubusercontent.com/1718655/68253520-62881a00-0028-11ea-9784-88c4849c992c.png">

I added some styling to the webui which should prevent the image from overflowing and hiding the buttons. 
As for now I opted to always show the buttons below the image and use the remaining space above for the image. If the image does not fit in this space, it is resized keeping the aspect ratio. 

Sadly this requires some javascript to calculate the actual browser height (100vh does not work on mobile) but hey... I did not add any recalculation, so the image does not work in all cases when the browser is resized (or the device is rotated) but a reload fixes this. Should be fine imho.

I also think, that it'd be fair to say, that the target group for the webui are modern browsers, so I used flexbox which does not work 100% on IE11 but on all "normal" mobile devices and browsers.

To make it easier to click the buttons, they are now a bit larger but probably somebody with a better feeling for aesthetics might have a look how they should look ;)

## How Has This Been Tested?
tested on mobile phone and desktop

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

