### PR TITLE
Bug Fix on AircrackOnly Plugin preventing it to load

### DIFF
--- a/pwnagotchi/plugins/default/AircrackOnly.py
+++ b/pwnagotchi/plugins/default/AircrackOnly.py
@@ -18,7 +18,6 @@ class AircrackOnly(plugins.Plugin):
     __description__ = 'confirm pcap contains handshake/PMKID or delete it'
 
     def __init__(self):
-        super().__init__(self)
         self.text_to_set = ""
 
     def on_loaded(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Unnecessary/Wrong call to the super init method prevents AircrackOnly to load during startup

## Description
Removed call to super(),__init__ method.

## Motivation and Context
Resolve issue 
- [ x ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
https://github.com/evilsocket/pwnagotchi/issues/536

## How Has This Been Tested?
Removed the call to super init method from local Pwnagotchi and restarted. AircrackOnly plugin now loads correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
