### PR TITLE
Add Fahrenheit and Kelvin temperature scales to memtemp.py

### DIFF
--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -58,10 +58,16 @@ class MemTemp(plugins.Plugin):
                                                    label_font=fonts.Small, text_font=fonts.Small))
 
     def on_ui_update(self, ui):
+        if self.options['scale'] == "fahrenheit":
+            temp = (pwnagotchi.temperature() * 9 / 5) + 32
+        elif self.options['scale'] == "celsius":
+            temp = pwnagotchi.temperature()
+        elif self.options['scale'] == "kelvin":
+            temp = pwnagotchi.temperature() + 273.15
         if self.options['orientation'] == "horizontal":
             ui.set('memtemp',
-                   " mem cpu temp\n %s%% %s%%  %sc" % (self.mem_usage(), self.cpu_load(), pwnagotchi.temperature()))
+                   " mem cpu temp\n %s%% %s%%  %sc" % (self.mem_usage(), self.cpu_load(), temp))
 
         elif self.options['orientation'] == "vertical":
             ui.set('memtemp',
-                   " mem:%s%%\n cpu:%s%%\ntemp:%sc" % (self.mem_usage(), self.cpu_load(), pwnagotchi.temperature()))
+                   " mem:%s%%\n cpu:%s%%\ntemp:%sc" % (self.mem_usage(), self.cpu_load(), temp))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
adding various temperature scales
## Description
<!--- Describe your changes in detail -->
Added Fahrenheit and Kelvin temperature conversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted Fahrenheit and figured why not add Kelvin too.

- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
https://github.com/evilsocket/pwnagotchi/issues/563


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested on my rpi0w hw v 1.1, pwnagotchi v1.2.1. set scale to 'celsius', 'fahrenheit', and 'kelvin' in config like:
memtemp:
    enabled: true
    scale: 'fahrenheit'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
