### PR TITLE
prevent double execution on gpio buttons

### DIFF
--- a/pwnagotchi/plugins/default/gpio_buttons.py
+++ b/pwnagotchi/plugins/default/gpio_buttons.py
@@ -34,5 +34,5 @@ class GPIOButtons(plugins.Plugin):
         for gpio, command in gpios.items():
             self.ports[gpio] = command
             GPIO.setup(gpio, GPIO.IN, GPIO.PUD_UP)
-            GPIO.add_event_detect(gpio, GPIO.FALLING, callback=self.runCommand, bouncetime=250)
+            GPIO.add_event_detect(gpio, GPIO.FALLING, callback=self.runCommand, bouncetime=600)
             logging.info("Added command: %s to GPIO #%d", command, gpio)


### PR DESCRIPTION
i had with the old value 250 many double executions, despite short push switches. The new value 600 prevents this.
Tested with volume buttons on v1.2.1.
