### PR TITLE
Ignore backup archives. Use 'find | xargs' to handle missing files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ output-pwnagotchi
 build
 dist
 pwnagotchi.egg-info
+*backup*.tgz
+*backup*.gz

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,7 +2,7 @@
 
 # name of the ethernet gadget interface on the host
 UNIT_HOSTNAME=${1:-10.0.0.2}
-# output backup zip file
+# output backup tgz file
 OUTPUT=${2:-pwnagotchi-backup.tgz}
 # username to use for ssh
 USERNAME=${3:-pi}
@@ -26,4 +26,4 @@ ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
 }
 
 echo "@ backing up $UNIT_HOSTNAME to $OUTPUT ..."
-ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo tar cv ${FILES_TO_BACKUP[@]}" | gzip -9 > "$OUTPUT"
+ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo find ${FILES_TO_BACKUP[@]} -print0 | xargs -0 sudo tar cv" | gzip -9 > "$OUTPUT"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -2,7 +2,7 @@
 
 # name of the ethernet gadget interface on the host
 UNIT_HOSTNAME=${1:-10.0.0.2}
-# output backup zip file
+# output backup tgz file
 BACKUP=${2:-pwnagotchi-backup.tgz}
 # username to use for ssh
 USERNAME=${3:-pi}


### PR DESCRIPTION
## Description
Two slight changes to backup behaviors
- Ignore backup archives
- Use `find | xargs` to gracefully handle missing files

Closes #497 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change #497

Current release backup script aborts on missing files, which an occur under normal operation. For instance if logrotate has not created any .gz files, or if the device has not connected to the grid.

## How Has This Been Tested?

I manually ran this new version of `backup.sh` to create a backup, then extracted the backup. This was test was performed on macOS 10.15.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] My code follows the code style of this project.

I actually can't find the style guide anywhere.