### PR TITLE
fixed memtemp location for inky display

### DIFF
--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -44,6 +44,9 @@ class MemTemp(plugins.Plugin):
         if ui.is_waveshare_v2():
             h_pos = (180, 80)
             v_pos = (180, 61)
+        elif ui.is_inky():
+            h_pos = (140, 68)
+            v_pos = (165, 54)
         else:
             h_pos = (155, 76)
             v_pos = (180, 61)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the coordinates for memtemp plugin on inky display

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes memtemp display bug on inky display
<!--- If it fixes an open issue, please link to the issue here. -->
#532
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested both vertical and horizontal config.
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on pi zero w with inkyphat (black) display.  pwnagotchi version 1.2.1
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
