### PR TITLE
Make backup / restore use POSIX shell for portability.

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,26 +1,54 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
+usage() {
+	echo "Usage: backup.sh [-honu] [-h] [-u user] [-n host name or ip] [-o output]"
+}
+
+while getopts "ho:n:u:" arg; do
+	case $arg in
+		h)
+			usage
+			exit
+			;;
+		n)
+			UNIT_HOSTNAME=$OPTARG
+			;;
+		o)
+			OUTPUT=$OPTARG
+			;;
+		u)
+			USERNAME=$OPTARG
+			;;
+		*)
+			usage
+			exit 1
+	esac
+done
 
 # name of the ethernet gadget interface on the host
-UNIT_HOSTNAME=${1:-10.0.0.2}
+UNIT_HOSTNAME=${UNIT_HOSTNAME:-10.0.0.2}
 # output backup tgz file
-OUTPUT=${2:-pwnagotchi-backup.tgz}
+OUTPUT=${OUTPUT:-${UNIT_HOSTNAME}-backup-$(date +%s).tgz}
 # username to use for ssh
-USERNAME=${3:-pi}
+USERNAME=${USERNAME:-pi}
 # what to backup
-FILES_TO_BACKUP=(
-  /root/brain.nn
-  /root/brain.json
-  /root/.api-report.json
-  /root/.bashrc
-  /root/handshakes
-  /root/peers
-  /etc/pwnagotchi/
-  /var/log/pwnagotchi.log
-  /var/log/pwnagotchi*.gz
-  /home/pi/.bashrc
-)
+FILES_TO_BACKUP="/root/brain.nn \
+  /root/brain.json \
+  /root/.api-report.json \
+  /root/.ssh \
+  /root/.bashrc \
+  /root/.profile \
+  /root/handshakes \
+  /root/peers \
+  /etc/pwnagotchi/ \
+  /etc/ssh/ \
+  /var/log/pwnagotchi.log \
+  /var/log/pwnagotchi*.gz \
+  /home/pi/.ssh \
+  /home/pi/.bashrc \
+  /home/pi/.profile"
 
-ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
+ping -w 3 -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1
 }

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,13 +1,50 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
+usage() {
+	echo "Usage: restore.sh [-bhnu] [-h] [-b backup name] [-n host name] [-u user name]"
+}
+
+while getopts "hb:n:u:" arg; do
+	case $arg in
+		b)
+			BACKUP=$OPTARG
+			;;
+		h)
+			usage
+			exit
+			;;
+		n)
+			UNIT_HOSTNAME=$OPTARG
+			;;
+		u)
+			USERNAME=$OPTARG
+			;;
+		*)
+			exit 1
+	esac
+done
 # name of the ethernet gadget interface on the host
-UNIT_HOSTNAME=${1:-10.0.0.2}
+UNIT_HOSTNAME=${UNIT_HOSTNAME:-10.0.0.2}
 # output backup tgz file
-BACKUP=${2:-pwnagotchi-backup.tgz}
+if [ -z $BACKUP ]; then
+	BACKUP=$(ls -rt ${UNIT_HOSTNAME}-backup-*.tgz 2>/dev/null | tail -n1)
+	if [ -z $BACKUP ]; then
+		echo "@ Can't find backup file. Please specify one with '-b'"
+		exit 1
+	fi
+	echo "@ Found backup file:"
+	echo "\t${BACKUP}"
+	echo -n "@ continue restroring this file? (y/n) "
+	read CONTINUE
+	CONTINUE=$(echo "${CONTINUE}" | tr "[:upper:]" "[:lower:]")
+	if [ "${CONTINUE}" != "y" ]; then
+		exit 1
+	fi
+fi
 # username to use for ssh
-USERNAME=${3:-pi}
+USERNAME=${USERNAME:-pi}
 
-ping -c 1 "${UNIT_HOSTNAME}" >/dev/null || {
+ping -w 3 -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1
 }


### PR DESCRIPTION
Signed-off-by: Aaron Bieber <aaron@bolddaemon.com>

Compatibility / Usability fixes for backup / restore scripts.

## Description

This removes the hard dependency on `bash` and adds `getopts` flags to the backup / restore scripts.

Removal of `bash` because there are simple scripts (no need for bash specific features), and not all systems ship with bash by default.

## Motivation and Context
Personally I can't remember the order of things like `$1`, `$2`, so every time I backup I have to view the scripts.


## How Has This Been Tested?
Backups and restores have been done.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
