### PR TITLE
Remove '-w' as macOS doesn't have it. Fix var expansion in dash.

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -48,10 +48,10 @@ FILES_TO_BACKUP="/root/brain.nn \
   /home/pi/.bashrc \
   /home/pi/.profile"
 
-ping -w 3 -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
+ping -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1
 }
 
 echo "@ backing up $UNIT_HOSTNAME to $OUTPUT ..."
-ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo find ${FILES_TO_BACKUP[@]} -print0 | xargs -0 sudo tar cv" | gzip -9 > "$OUTPUT"
+ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo find ${FILES_TO_BACKUP} -print0 | xargs -0 sudo tar cv" | gzip -9 > "$OUTPUT"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -44,7 +44,7 @@ fi
 # username to use for ssh
 USERNAME=${USERNAME:-pi}
 
-ping -w 3 -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
+ping -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
   exit 1
 }


### PR DESCRIPTION
Signed-off-by: Aaron Bieber <aaron@bolddaemon.com>

This fixes bugs introduced by https://github.com/evilsocket/pwnagotchi/pull/580

I have confirmed that Ubuntu (dash - thanks to @kovachwt), macOS (zsh), and OpenBSD (ksh) work as expected.