### PR TITLE
make label to value space configurable to better fit small fonts

### DIFF
--- a/pwnagotchi/ui/components.py
+++ b/pwnagotchi/ui/components.py
@@ -58,12 +58,13 @@ class Text(Widget):
 
 
 class LabeledValue(Widget):
-    def __init__(self, label, value="", position=(0, 0), label_font=None, text_font=None, color=0):
+    def __init__(self, label, value="", position=(0, 0), label_font=None, text_font=None, color=0, label_spacing=5):
         super().__init__(position, color)
         self.label = label
         self.value = value
         self.label_font = label_font
         self.text_font = text_font
+        self.label_spacing = label_spacing
 
     def draw(self, canvas, drawer):
         if self.label is None:
@@ -71,4 +72,4 @@ class LabeledValue(Widget):
         else:
             pos = self.xy
             drawer.text(pos, self.label, font=self.label_font, fill=self.color)
-            drawer.text((pos[0] + 5 + 5 * len(self.label), pos[1]), self.value, font=self.text_font, fill=self.color)
+            drawer.text((pos[0] + self.label_spacing + 5 * len(self.label), pos[1]), self.value, font=self.text_font, fill=self.color)


### PR DESCRIPTION
## Description
to display things such as the gps coordinates in small fonts, the spacing between label and value is a little too large if we consider the limited space available on the screen.

Demo usage with gps coordinates... left new, right old - **just look at the space between the lat label & value**, the others are fakes with whitespaces...
![image](https://user-images.githubusercontent.com/512997/68801521-8963d300-065c-11ea-9be7-91a5db353dcb.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
