### PR TITLE
Fixed Paw-Gps config, added a - mark

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -71,7 +71,7 @@ main:
             enabled: false
             scale: celsius
             orientation: horizontal # horizontal/vertical
-        pawgps:
+        paw-gps:
             enabled: false
             #The IP Address of your phone with Paw Server running, default (option is empty) is 192.168.44.1
             ip: ''


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before, paw-gps was set as pawgps in the config, this was different than the filename (paw-gps.py) so it didnt work, this request should fix that. (if this is the place that sets /etc/pwnagotchi/default.yml, this is my first PR so sorry im dumb)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> Tested on my own unit, pawgps starts now, before it didnt.
<!--- Include details of your testing environment, and the tests you ran to --> rpi0w, waveshare v2, android phone with pawgps set up.
<!--- see how your change affects other areas of the code, etc. --> It shouldnt affect anything else its just a change to default.yml lol

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
