### PR TITLE
decrease spacing in gps ui

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -63,6 +63,8 @@ class GPS(plugins.Plugin):
             lon_pos = (127, 56)
             alt_pos = (102, 71)
 
+        label_spacing = 0
+
         ui.add_element(
             "latitude",
             LabeledValue(
@@ -72,6 +74,7 @@ class GPS(plugins.Plugin):
                 position=lat_pos,
                 label_font=fonts.Small,
                 text_font=fonts.Small,
+                label_spacing=label_spacing,
             ),
         )
         ui.add_element(
@@ -83,6 +86,7 @@ class GPS(plugins.Plugin):
                 position=lon_pos,
                 label_font=fonts.Small,
                 text_font=fonts.Small,
+                label_spacing=label_spacing,
             ),
         )
         ui.add_element(
@@ -94,6 +98,7 @@ class GPS(plugins.Plugin):
                 position=alt_pos,
                 label_font=fonts.Small,
                 text_font=fonts.Small,
+                label_spacing=label_spacing,
             ),
         )
 
@@ -102,6 +107,8 @@ class GPS(plugins.Plugin):
             # avoid 0.000... measurements
             self.coordinates["Latitude"], self.coordinates["Longitude"]
         ]):
-            ui.set("latitude", f"{self.coordinates['Latitude']:.4f}")
-            ui.set("longitude", f" {self.coordinates['Longitude']:.4f}")
-            ui.set("altitude", f" {self.coordinates['Altitude']:.1f}m")
+            # last char is sometimes not completely drawn ¯\_(ツ)_/¯
+            # using an ending-whitespace as workaround on each line
+            ui.set("latitude", f"{self.coordinates['Latitude']:.4f} ")
+            ui.set("longitude", f" {self.coordinates['Longitude']:.4f} ")
+            ui.set("altitude", f" {self.coordinates['Altitude']:.1f}m ")


### PR DESCRIPTION
##  Description
make the gps coordinates label-value more narrow to save some space. possible since  #605

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
