### PR TITLE
webgpsmap plugin - fixed check for nonzero lat/long

### DIFF
--- a/pwnagotchi/plugins/default/webgpsmap.py
+++ b/pwnagotchi/plugins/default/webgpsmap.py
@@ -338,7 +338,7 @@ class PositionFile:
                 lat = self._json['Latitude']
             if self.type() == PositionFile.GEO:
                 lat = self._json['location']['lat']
-            if lat > 0:
+            if lat != 0:
                 return lat
             raise ValueError("Lat is 0")
         except KeyError:
@@ -351,7 +351,7 @@ class PositionFile:
                 lng = self._json['Longitude']
             if self.type() == PositionFile.GEO:
                 lng = self._json['location']['lng']
-            if lng > 0:
+            if lng != 0:
                 return lng
             raise ValueError("Lng is 0")
         except KeyError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows for negative latitude and longitude values in webgpsmap plugin

## Description
<!--- Describe your changes in detail -->
Fixed a check in webgpsmap plugin that did not allow negative latitude and longitude values

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
#611 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Loaded webgpsmap plugin with negative longitude values in geo.json files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
