### PR TITLE
fix: don't use $USERNAME as default username for backup/restore scripts, as this is usually defined on linux hosts as the current logged in user

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,7 +17,7 @@ while getopts "ho:n:u:" arg; do
 			OUTPUT=$OPTARG
 			;;
 		u)
-			USERNAME=$OPTARG
+			UNIT_USERNAME=$OPTARG
 			;;
 		*)
 			usage
@@ -30,7 +30,7 @@ UNIT_HOSTNAME=${UNIT_HOSTNAME:-10.0.0.2}
 # output backup tgz file
 OUTPUT=${OUTPUT:-${UNIT_HOSTNAME}-backup-$(date +%s).tgz}
 # username to use for ssh
-USERNAME=${USERNAME:-pi}
+UNIT_USERNAME=${UNIT_USERNAME:-pi}
 # what to backup
 FILES_TO_BACKUP="/root/brain.nn \
   /root/brain.json \
@@ -54,4 +54,4 @@ ping -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
 }
 
 echo "@ backing up $UNIT_HOSTNAME to $OUTPUT ..."
-ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo find ${FILES_TO_BACKUP} -print0 | xargs -0 sudo tar cv" | gzip -9 > "$OUTPUT"
+ssh "${UNIT_USERNAME}@${UNIT_HOSTNAME}" "sudo find ${FILES_TO_BACKUP} -print0 | xargs -0 sudo tar cv" | gzip -9 > "$OUTPUT"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -17,7 +17,7 @@ while getopts "hb:n:u:" arg; do
 			UNIT_HOSTNAME=$OPTARG
 			;;
 		u)
-			USERNAME=$OPTARG
+			UNIT_USERNAME=$OPTARG
 			;;
 		*)
 			exit 1
@@ -42,7 +42,7 @@ if [ -z $BACKUP ]; then
 	fi
 fi
 # username to use for ssh
-USERNAME=${USERNAME:-pi}
+UNIT_USERNAME=${UNIT_USERNAME:-pi}
 
 ping -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
   echo "@ unit ${UNIT_HOSTNAME} can't be reached, make sure it's connected and a static IP assigned to the USB interface."
@@ -50,4 +50,4 @@ ping -c 1 "${UNIT_HOSTNAME}" > /dev/null 2>&1 || {
 }
 
 echo "@ restoring $BACKUP to $UNIT_HOSTNAME ..."
-cat ${BACKUP} | ssh "${USERNAME}@${UNIT_HOSTNAME}" "sudo tar xzv -C /"
+cat ${BACKUP} | ssh "${UNIT_USERNAME}@${UNIT_HOSTNAME}" "sudo tar xzv -C /"


### PR DESCRIPTION
## Description
I noticed that running the backup script with no parameters caused the script to log into the pi as my current username instead of 'pi', which is probably not what most people running a default pwnagotchi install will want. This is caused by $USERNAME being defined already in the default environment of most linux shells. This change dis-ambiguates the variable name into $UNIT_USERNAME instead to avoid clashing.

## Motivation and Context
Default install friendly defaults are nice :)

## How Has This Been Tested?
Ran the script before the change, it tried to log in as my current user. Tried again after the change, and it correctly logged in as 'pi' and backed up my shtuff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
