### PR TITLE
Fix for issue #616

### DIFF
--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -51,26 +51,32 @@ class MemTemp(plugins.Plugin):
             h_pos = (155, 76)
             v_pos = (180, 61)
 
-        if self.options['orientation'] == "horizontal":
-            ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value='mem cpu temp\n - -  -',
-                                                   position=h_pos,
-                                                   label_font=fonts.Small, text_font=fonts.Small))
-        elif self.options['orientation'] == "vertical":
+        if self.options['orientation'] == "vertical":
             ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value=' mem:-\n cpu:-\ntemp:-',
                                                    position=v_pos,
+                                                   label_font=fonts.Small, text_font=fonts.Small))
+        else:
+            # default to horizontal
+            ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value='mem cpu temp\n - -  -',
+                                                   position=h_pos,
                                                    label_font=fonts.Small, text_font=fonts.Small))
 
     def on_ui_update(self, ui):
         if self.options['scale'] == "fahrenheit":
             temp = (pwnagotchi.temperature() * 9 / 5) + 32
-        elif self.options['scale'] == "celsius":
-            temp = pwnagotchi.temperature()
+            symbol = "f"
         elif self.options['scale'] == "kelvin":
             temp = pwnagotchi.temperature() + 273.15
-        if self.options['orientation'] == "horizontal":
-            ui.set('memtemp',
-                   " mem cpu temp\n %s%% %s%%  %sc" % (self.mem_usage(), self.cpu_load(), temp))
+            symbol = "k"
+        else:
+            # default to celsius 
+            temp = pwnagotchi.temperature()
+            symbol = "c"
 
-        elif self.options['orientation'] == "vertical":
+        if self.options['orientation'] == "vertical":
             ui.set('memtemp',
-                   " mem:%s%%\n cpu:%s%%\ntemp:%sc" % (self.mem_usage(), self.cpu_load(), temp))
+                   " mem:%s%%\n cpu:%s%%\ntemp:%s%s" % (self.mem_usage(), self.cpu_load(), temp, symbol))
+        else:
+            # default to horizontal
+            ui.set('memtemp',
+                   " mem cpu temp\n %s%% %s%%  %s%s" % (self.mem_usage(), self.cpu_load(), temp, symbol))


### PR DESCRIPTION
- Fix the temperature symbol when using something other than celsius (https://github.com/evilsocket/pwnagotchi/issues/616)
- Add defaults so we don't throw an exception if an invalid scale is
selected. Bad things happen if you spell fahrenheit wrong.