### PR TITLE
fix: apparently for the led, 0 is ON and 1 is OFF

### DIFF
--- a/pwnagotchi/plugins/default/led.py
+++ b/pwnagotchi/plugins/default/led.py
@@ -44,12 +44,12 @@ class Led(plugins.Plugin):
         logging.debug("[led] using pattern '%s' ..." % pattern)
         for c in pattern:
             if c == ' ':
-                self._led(0)
-            else:
                 self._led(1)
+            else:
+                self._led(0)
             time.sleep(self._delay / 1000.0)
         # reset
-        self._led(1)
+        self._led(0)
 
     def _worker(self):
         while True:


### PR DESCRIPTION
## Description
I noticed that the led plugin was causing the LED to be off after every blink pattern was completed. Looks like this was caused by the /sys/class/led/led0/brightness file expecting 0 to turn the led on and 1 to turn the led off. Very strange, but this PR "fixes" the logic.

## How Has This Been Tested?
Ran the new code and observed that the LED stays on after blink patterns are complete, as one would probably want (otherwise you can't even tell if the pi is on!)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
