### PR TITLE
fix gps iso-datetime parsing

### DIFF
--- a/pwnagotchi/plugins/default/webgpsmap.py
+++ b/pwnagotchi/plugins/default/webgpsmap.py
@@ -293,9 +293,9 @@ class PositionFile:
         elif 'Updated' in self._json:
             # convert gps datetime to unix timestamp: "2019-10-05T23:12:40.422996+01:00"
             date_iso_formated = self._json['Updated']
-            # fill milliseconds to 6 numbers
+            # fill/cut microseconds to 6 numbers
             part1, part2, part3 = re.split('\.|\+', date_iso_formated)
-            part2 = part2.ljust(6, '0')
+            part2 = part2.ljust(6, '0')[:6]
             date_iso_formated = part1 + "." + part2 + "+" + part3
             dateObj = datetime.datetime.fromisoformat(date_iso_formated)
             return_ts = int("%.0f" % dateObj.timestamp())


### PR DESCRIPTION
problem on timestamp parsing if microseconds are more then 6 numbers.

will fix bug reported in this pr: https://github.com/evilsocket/pwnagotchi/pull/619

tested with testdata from https://github.com/xenDE/pwnagotchi-plugin-webgpsmap/tree/master/handshakes.gps-map-test

before:

```
[2019-11-19 00:37:51,946] [INFO] webgpsmap: scanning /root/handshakes.gps-map-test
[2019-11-19 00:37:52,022] [INFO] webgpsmap: Found 4 .(geo|gps).json files from 5 handshakes. Fetching positions ...
[2019-11-19 00:37:52,144] [ERROR] Lng is 0
[2019-11-19 00:37:52,241] [ERROR] Invalid isoformat string: '2019-11-14T12:30:41.097414739+01:00'
[2019-11-19 00:37:52,280] [ERROR] Lng is 0
[2019-11-19 00:37:52,329] [INFO] webgpsmap loaded 2 positions
```

after:

```
[2019-11-19 00:48:04,652] [INFO] webgpsmap: scanning /root/handshakes.gps-map-test
[2019-11-19 00:48:04,693] [INFO] webgpsmap: Found 5 .(geo|gps).json files from 6 handshakes. Fetching positions ...
[2019-11-19 00:48:04,760] [ERROR] Lng is 0
[2019-11-19 00:48:04,822] [ERROR] Lng is 0
[2019-11-19 00:48:04,850] [INFO] webgpsmap loaded 3 positions
```

