### PR TITLE
fix gpio_buttons plugin: gpio needs to be a number

### DIFF
--- a/pwnagotchi/plugins/default/gpio_buttons.py
+++ b/pwnagotchi/plugins/default/gpio_buttons.py
@@ -32,6 +32,7 @@ class GPIOButtons(plugins.Plugin):
         GPIO.setmode(GPIO.BCM)
 
         for gpio, command in gpios.items():
+            gpio = int(gpio)
             self.ports[gpio] = command
             GPIO.setup(gpio, GPIO.IN, GPIO.PUD_UP)
             GPIO.add_event_detect(gpio, GPIO.FALLING, callback=self.runCommand, bouncetime=600)


### PR DESCRIPTION
fixes handling gpio-id as string from config
fixes: https://github.com/evilsocket/pwnagotchi/issues/643
