### PR TITLE
[BUGFIX] Prevent duplicate entries for reported networks

### DIFF
--- a/pwnagotchi/plugins/default/grid.py
+++ b/pwnagotchi/plugins/default/grid.py
@@ -67,7 +67,8 @@ class Grid(plugins.Plugin):
         logging.info("grid plugin loaded.")
 
     def set_reported(self, reported, net_id):
-        reported.append(net_id)
+        if net_id not in reported:
+            reported.append(net_id)
         self.report.update(data={'reported': reported})
 
     def check_inbox(self, agent):


### PR DESCRIPTION
## Description
Due to duplicate entries in `/root/.api-report.json`, [this code](https://github.com/evilsocket/pwnagotchi/blob/master/pwnagotchi/plugins/default/grid.py#L90) incorrectly reports the number of pwned networks, resulting in incorrect stats on the [pwnagotchi.ai website](https://pwnagotchi.ai/). This PR fixes that problem by adding a check that the entries to be added don't already exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [#657] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I cleared my `/root/.api-report.json` using:
```python3
import json

with open(’.api-report.json’) as json_file:
    data = json.load(json_file)

print( "Entries before: " + str(len(data[‘reported’])))
data = list(dict.fromkeys(data[‘reported’]))
print( "Entries with no duplicates: " + str(len(data)))

output = {}
output[‘reported’] = data

with open(‘fixed.json’, ‘w’) as outfile:
    json.dump(output, outfile)
```
Then updated the code locally. Pwned networks are now being reported correctly.
