### PR TITLE
Add plugins page

### DIFF
--- a/pwnagotchi/plugins/default/bt-tether.py
+++ b/pwnagotchi/plugins/default/bt-tether.py
@@ -466,7 +466,11 @@ class BTTether(plugins.Plugin):
         logging.info("BT-TETHER: Successfully loaded ...")
         self.ready = True
 
+    def on_unload(self):
+        self.ui.remove_element('bluetooth')
+
     def on_ui_setup(self, ui):
+        self.ui = ui
         ui.add_element('bluetooth', LabeledValue(color=BLACK, label='BT', value='-', position=(ui.width() / 2 - 15, 0),
                                                  label_font=fonts.Bold, text_font=fonts.Medium))
 

--- a/pwnagotchi/plugins/default/example.py
+++ b/pwnagotchi/plugins/default/example.py
@@ -25,6 +25,10 @@ class Example(plugins.Plugin):
     def on_loaded(self):
         logging.warning("WARNING: this plugin should be disabled! options = " % self.options)
 
+    # called before the plugin is unloaded
+    def on_unload(self):
+        pass
+
     # called hen there's internet connectivity
     def on_internet_available(self, agent):
         pass

--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -32,3 +32,36 @@ a.read {
 p.messagebody {
     padding: 1em;
 }
+
+li.navitem {
+    width: 16.66% !important;
+    clear: none !important;
+}
+
+/* Custom indentations are needed because the length of custom labels differs from
+   the length of the standard labels */
+.custom-size-flipswitch.ui-flipswitch .ui-btn.ui-flipswitch-on {
+    text-indent: -5.9em;
+}
+
+.custom-size-flipswitch.ui-flipswitch .ui-flipswitch-off {
+    text-indent: 0.5em;
+}
+
+/* Custom widths are needed because the length of custom labels differs from
+   the length of the standard labels */
+.custom-size-flipswitch.ui-flipswitch {
+    width: 8.875em;
+}
+
+.custom-size-flipswitch.ui-flipswitch.ui-flipswitch-active {
+    padding-left: 7em;
+    width: 1.875em;
+}
+
+@media (min-width: 28em) {
+    /*Repeated from rule .ui-flipswitch above*/
+    .ui-field-contain > label + .custom-size-flipswitch.ui-flipswitch {
+        width: 1.875em;
+    }
+}

--- a/pwnagotchi/ui/web/templates/base.html
+++ b/pwnagotchi/ui/web/templates/base.html
@@ -47,6 +47,7 @@
         ( '/inbox/new', 'new', 'mail', 'New' ),
         ( '/inbox/profile', 'profile', 'info', 'Profile' ),
         ( '/inbox/peers', 'peers', 'user', 'Peers' ),
+        ( '/plugins', 'plugins', 'grid', 'Plugins' ),
     ] %}
     {% set active_page = active_page|default('inbox') %}
 
@@ -54,7 +55,7 @@
         <div data-role="navbar" data-iconpos="left">
             <ul>
                 {% for href, id, icon, caption in navigation %}
-                    <li>
+                    <li class="navitem">
                        <a href="{{ href }}" id="{{ id }}" data-icon="{{ icon }}" class="{{ 'ui-btn-active' if active_page == id }}">{{ caption }}</a>
                     </li>
                 {% endfor %}

--- a/pwnagotchi/ui/web/templates/plugins.html
+++ b/pwnagotchi/ui/web/templates/plugins.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% set active_page = "plugins" %}
+
+{% block title %}
+Plugins
+{% endblock %}
+
+{% block script %}
+$(function(){
+    $("input[type=checkbox]").change(function(e) {
+          var checkbox = $(this);
+          var form = checkbox.closest("form");
+          var url = form.attr('action');
+
+          $.ajax({
+             type: "POST",
+             url: url,
+             data: form.serialize(),
+             success: function(data) {
+                  if( data.indexOf('failed') != -1 ) {
+                      alert('Could not be toggled.');
+                  }
+            }
+        });
+    });
+});
+{% endblock %}
+{% block content %}
+<div style="padding: 1em">
+    {% for name in database.keys() %}
+      <h4>{{name}}</h4>
+      <form method="POST" action="/plugins/toggle">
+        <input type="checkbox" data-role="flipswitch" name="enabled" id="flip-checkbox-{{name}}" data-on-text="Enabled" data-off-text="Disabled" data-wrapper-class="custom-size-flipswitch" {% if name in loaded %} checked {% endif %}>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <input type="hidden" name="plugin" value="{{ name }}"/>
+      </form>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds:
- /plugins site which can be used to enable/disable plugins
- on_unload event (triggered when plugin gets disabled; can be used to remove ui elements or to save data)
- database variable which contains all plugins (database[name]-> filename)

![Plugin Page](https://i.imgur.com/BeRAa4n.png)
