### PR TITLE
added on_unfiltered_wifi_list

### DIFF
--- a/pwnagotchi/plugins/default/example.py
+++ b/pwnagotchi/plugins/default/example.py
@@ -122,6 +122,11 @@ class Example(plugins.Plugin):
     def on_wifi_update(self, agent, access_points):
         pass
 
+    # called when the agent refreshed an unfiltered access point list
+    # this list contains all access points that were detected BEFORE filtering
+    def on_unfiltered_ap_list(self, agent, access_points):
+        pass
+
     # called when the agent is sending an association frame
     def on_association(self, agent, access_point):
         pass


### PR DESCRIPTION
Signed-off-by: Casey Diemel <diemelcw@gmail.com>

adds ability to review an unfiltered list of APs, in a plugin, that have been detected for further processing.  Code that was not added with previous pull request/issue that was raised. 

## Description
Added `on_unfiltered_ap_list' to example.py

## Motivation and Context
#668 - issue to add on_unfiltered_ap_list to example.py
#285 - merge to add on_unfiltered_ap_list to agent.py
#270 - discussion about adding to agent.py
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md)) (#668)


## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
