### PR TITLE
[FEATURE] Plugin for downloading captured handshakes

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -115,6 +115,8 @@ main:
                 peer_lost: 'oo  oo  oo oo  oo  oo  oo'
         webcfg:
           enabled: false
+        handhsakes-dl:
+            enabled: false
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already

--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -115,7 +115,7 @@ main:
                 peer_lost: 'oo  oo  oo oo  oo  oo  oo'
         webcfg:
           enabled: false
-        handhsakes-dl:
+        handshakes-dl:
             enabled: false
     # monitor interface to use
     iface: mon0

--- a/pwnagotchi/plugins/default/handshakes-dl.py
+++ b/pwnagotchi/plugins/default/handshakes-dl.py
@@ -57,7 +57,7 @@ class HandshakesDL(plugins.Plugin):
             handshakes = glob.glob(os.path.join(self.config['bettercap']['handshakes'], "*.pcap"))
             handshakes = [os.path.basename(path)[:-5] for path in handshakes]
             return render_template_string(TEMPLATE,
-                                    title="Handhakes | " + pwnagotchi.name(),
+                                    title="Handshakes | " + pwnagotchi.name(),
                                     handshakes=handshakes)
 
         else:

--- a/pwnagotchi/plugins/default/handshakes-dl.py
+++ b/pwnagotchi/plugins/default/handshakes-dl.py
@@ -29,7 +29,7 @@ TEMPLATE = """
 {% endblock %}
 """
 
-class HandshakeDL(plugins.Plugin):
+class HandshakesDL(plugins.Plugin):
     __author__ = 'me@sayakb.com'
     __version__ = '0.1.0'
     __license__ = 'GPL3'

--- a/pwnagotchi/plugins/default/handshakes-dl.py
+++ b/pwnagotchi/plugins/default/handshakes-dl.py
@@ -1,0 +1,64 @@
+import logging
+import json
+import os
+import glob
+
+import pwnagotchi
+import pwnagotchi.plugins as plugins
+
+from flask import abort
+from flask import send_from_directory
+from flask import render_template_string
+
+TEMPLATE = """
+{% extends "base.html" %}
+{% set active_page = "handshakes" %}
+
+{% block title %}
+    {{ title }}
+{% endblock %}
+
+{% block content %}
+    <ul id="list" data-role="listview" style="list-style-type:disc;">
+        {% for handshake in handshakes %}
+            <li class="file">
+                <a href="/handshakes/{{handshake}}">{{handshake}}</a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock %}
+"""
+
+class HandshakeDL(plugins.Plugin):
+    __author__ = 'me@sayakb.com'
+    __version__ = '0.1.0'
+    __license__ = 'GPL3'
+    __description__ = 'Download handshake captures from web-ui.'
+
+    def __init__(self):
+        self.ready = False
+
+    def on_loaded(self):
+        logging.info("HandshakeDL plugin loaded")
+
+    def on_ready(self, agent):
+        self.agent = agent
+        self.ready = True
+
+    def on_webhook(self, path, request):
+        if not self.ready:
+            return "Plugin not ready"
+
+        if path == "/" or not path:
+            handshakes = glob.glob(os.path.join(self.agent.config()['bettercap']['handshakes'], "*.pcap"))
+            handshakes = [os.path.basename(path)[:-5] for path in handshakes]
+            return render_template_string(TEMPLATE,
+                                    title="Handhakes | " + pwnagotchi.name(),
+                                    handshakes=handshakes)
+
+        else:
+            dir = self.agent.config()['bettercap']['handshakes']
+            try:
+                return send_from_directory(directory=dir, filename=path+'.pcap', as_attachment=True)
+            except FileNotFoundError:
+                abort(404)


### PR DESCRIPTION
Adds a plugin for downloading captured handshakes via the web-ui using the `on_webhook()` method.

## Motivation and Context
- Would enabling downloading .pcap files on platforms with limited scp support (eg. phones)
- [#655] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested thoroughly on the `master` branch  as well as `v1.3.0` release on the RPi-0W.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)