### PR TITLE
fix: Prevent duplicate entries for uploaded pcaps

### DIFF
--- a/pwnagotchi/plugins/default/onlinehashcrack.py
+++ b/pwnagotchi/plugins/default/onlinehashcrack.py
@@ -92,9 +92,10 @@ class OnlineHashCrack(plugins.Plugin):
                     display.update(force=True)
                     try:
                         self._upload_to_ohc(handshake)
-                        reported.append(handshake)
-                        self.report.update(data={'reported': reported})
-                        logging.info(f"OHC: Successfully uploaded {handshake}")
+                        if handshake not in reported:
+                            reported.append(handshake)
+                            self.report.update(data={'reported': reported})
+                            logging.info(f"OHC: Successfully uploaded {handshake}")
                     except requests.exceptions.RequestException as req_e:
                         self.skip.append(handshake)
                         logging.error("OHC: %s", req_e)


### PR DESCRIPTION
For the same reasons like described here https://github.com/evilsocket/pwnagotchi/issues/657 duplicated entries could be created in /root/.ohc_uploads

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added a check if pcap name is already in /root/.ohc_uploads before the file is updated

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
Since plugin event handlers are running asynchronously in some circumstances there could be multiple entries created for the same pcap

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After updating the code locally, I cleared file /root/.ohc_uploads and reuploaded all handshakes - getting the right number of entries stored in the file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ x] I have signed-off my commits with `git commit -s`
