### PR TITLE
improvement of the plugins web page

### DIFF
--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -72,10 +72,11 @@ li.navitem {
     justify-content: space-around;
 }
 
-.element {
+.plugins-box {
     margin: 0.5rem;
     padding: 0.2rem;
     border-style: groove;
     border-radius: 0.5rem;
     background-color: lightgrey;
+    text-align: center;
 }

--- a/pwnagotchi/ui/web/static/css/style.css
+++ b/pwnagotchi/ui/web/static/css/style.css
@@ -65,3 +65,17 @@ li.navitem {
         width: 1.875em;
     }
 }
+
+#container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}
+
+.element {
+    margin: 0.5rem;
+    padding: 0.2rem;
+    border-style: groove;
+    border-radius: 0.5rem;
+    background-color: lightgrey;
+}

--- a/pwnagotchi/ui/web/templates/plugins.html
+++ b/pwnagotchi/ui/web/templates/plugins.html
@@ -28,7 +28,7 @@ $(function(){
 {% block content %}
 <div id="container">
     {% for name in database.keys() %}
-        <div class="element">
+        <div class="plugins-box">
           <h4>
             <a {% if name in loaded and loaded[name].on_webhook is defined %} href="/plugins/{{name}}" {% endif %}>{{name}}</a>
           </h4>

--- a/pwnagotchi/ui/web/templates/plugins.html
+++ b/pwnagotchi/ui/web/templates/plugins.html
@@ -26,16 +26,18 @@ $(function(){
 });
 {% endblock %}
 {% block content %}
-<div style="padding: 1em">
+<div id="container">
     {% for name in database.keys() %}
-      <h4>
-        <a {% if name in loaded and loaded[name].on_webhook is defined %} href="/plugins/{{name}}" {% endif %}>{{name}}</a>
-      </h4>
-      <form method="POST" action="/plugins/toggle">
-        <input type="checkbox" data-role="flipswitch" name="enabled" id="flip-checkbox-{{name}}" data-on-text="Enabled" data-off-text="Disabled" data-wrapper-class="custom-size-flipswitch" {% if name in loaded %} checked {% endif %}>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <input type="hidden" name="plugin" value="{{ name }}"/>
-      </form>
+        <div class="element">
+          <h4>
+            <a {% if name in loaded and loaded[name].on_webhook is defined %} href="/plugins/{{name}}" {% endif %}>{{name}}</a>
+          </h4>
+          <form method="POST" action="/plugins/toggle">
+            <input type="checkbox" data-role="flipswitch" name="enabled" id="flip-checkbox-{{name}}" data-on-text="Enabled" data-off-text="Disabled" data-wrapper-class="custom-size-flipswitch" {% if name in loaded %} checked {% endif %}>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <input type="hidden" name="plugin" value="{{ name }}"/>
+          </form>
+        </div>
     {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Improved display style of different plugins

## Description
Instead of displaying the plugins in a single column, I modified the "style.css" file so that the plugins are displayed in boxes on several lines.

## Motivation and Context
I did not propose this modification before make the pull request, I hope that it does not pose a problem.
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
The tests were done in Chrome and Firefox browsers on PC and Oneplus 3T smartphone.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
