### PR TITLE
Added text overflow checking for over 999 associations

### DIFF
--- a/pwnagotchi/voice.py
+++ b/pwnagotchi/voice.py
@@ -161,7 +161,10 @@ class Voice:
 
     def on_last_session_data(self, last_session):
         status = self._('Kicked {num} stations\n').format(num=last_session.deauthed)
-        status += self._('Made {num} new friends\n').format(num=last_session.associated)
+        if last_session.associated > 999:
+            status += self._('Made >999 new friends\n')
+        else:
+            status += self._('Made {num} new friends\n').format(num=last_session.associated)
         status += self._('Got {num} handshakes\n').format(num=last_session.handshakes)
         if last_session.peers == 1:
             status += self._('Met 1 peer')


### PR DESCRIPTION
Added text overflow checking for over 999 associations

## Description
Changed code so that if a pwnagotchi enters manual mode with over 999 associations it doesn't overflow the text screen. 

## Motivation and Context
Resolved Issue #634 
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/issues/634))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
