### PR TITLE
Set correct position for memtemp plugin so that it does not overlap with regular messages for waveshare27inch.

### DIFF
--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -53,6 +53,9 @@ class MemTemp(plugins.Plugin):
         elif ui.is_inky():
             h_pos = (140, 68)
             v_pos = (165, 54)
+        elif ui.is_waveshare27inch():
+            h_pos = (192, 138)
+            v_pos = (216, 122)
         else:
             h_pos = (155, 76)
             v_pos = (180, 61)

--- a/pwnagotchi/ui/hw/waveshare27inch.py
+++ b/pwnagotchi/ui/hw/waveshare27inch.py
@@ -6,7 +6,7 @@ from pwnagotchi.ui.hw.base import DisplayImpl
 
 class Waveshare27inch(DisplayImpl):
     def __init__(self, config):
-        super(Waveshare27inch, self).__init__(config, 'waveshare_2_7inch')
+        super(Waveshare27inch, self).__init__(config, 'waveshare27inch')
         self._display = None
 
     def layout(self):


### PR DESCRIPTION
## Description
Added correct potision in memtemp.py
Fixed the config screen name in waveshare27inch.py. So far, the is_waveshare27inch() function always returned false.

## Motivation and Context
pwnagotchi messages overlap with the memtemp text which makes temp unreadable.
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
#726 #702

## How Has This Been Tested?
This has been tested directly on a raspberry pi zero, using the standard pwnagotchi image and a physical waveshare27inch screen.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
