### PR TITLE
ups_lite: Add auto-shutdown

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -116,6 +116,9 @@ main:
           enabled: false
         session-stats:
           enabled: true
+        ups_lite:
+          enabled: false
+          shutdown: 2  # Auto-shutdown when <= 2%
     # monitor interface to use
     iface: mon0
     # command to run to bring the mon interface up in case it's not up already

--- a/pwnagotchi/plugins/default/ups_lite.py
+++ b/pwnagotchi/plugins/default/ups_lite.py
@@ -7,12 +7,14 @@
 # For Raspberry Pi Zero Ups Power Expansion Board with Integrated Serial Port S3U4
 # https://www.ebay.de/itm/For-Raspberry-Pi-Zero-Ups-Power-Expansion-Board-with-Integrated-Serial-Port-S3U4/323873804310
 # https://www.aliexpress.com/item/32888533624.html
+import logging
 import struct
 
 from pwnagotchi.ui.components import LabeledValue
 from pwnagotchi.ui.view import BLACK
 import pwnagotchi.ui.fonts as fonts
 import pwnagotchi.plugins as plugins
+import pwnagotchi
 
 
 # TODO: add enable switch in config.yml an cleanup all to the best place
@@ -63,4 +65,9 @@ class UPSLite(plugins.Plugin):
             ui.remove_element('ups')
 
     def on_ui_update(self, ui):
-        ui.set('ups', "%2i%%" % self.ups.capacity())
+        capacity = self.ups.capacity()
+        ui.set('ups', "%2i%%" % capacity)
+        if capacity <= self.options['shutdown']:
+            logging.info('[ups_lite] Empty battery (<= %s%%): shuting down' % self.options['shutdown'])
+            ui.update(force=True, new_data={'status': 'Battery exhausted, bye ...'})
+            pwnagotchi.shutdown()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the battery level comes below a certain %, auto-shutdown to prevent loosing data.

## Motivation and Context
https://github.com/evilsocket/pwnagotchi/issues/650#issue-528008477
- [x] Someone else have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Setting the threshold way too high, and seeing it go down.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
