### PR TITLE
Add Linux SD Card Backup Script

### DIFF
--- a/scripts/dirs.list
+++ b/scripts/dirs.list
@@ -1,0 +1,15 @@
+/root/brain.nn
+/root/brain.json
+/root/.api-report.json
+/root/.ssh
+/root/.bashrc
+/root/.profile
+/root/handshakes
+/root/peers
+/etc/pwnagotchi/
+/etc/ssh/
+/var/log/pwnagotchi.log
+/var/log/pwnagotchi*.gz
+/home/pi/.ssh
+/home/pi/.bashrc
+/home/pi/.profile

--- a/scripts/sd_backup.sh
+++ b/scripts/sd_backup.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+usage() {
+	echo "Usage: sd_backup.sh [-hod] [-h] [-d rootfs dir] [-o output]"
+}
+
+while getopts "ho:d:u:" arg; do
+	case $arg in
+		h)
+			usage
+			exit
+			;;
+		d)
+			SD_DIR=$OPTARG
+			;;
+		o)
+			OUTPUT=$OPTARG
+			;;
+		*)
+			usage
+			exit 1
+	esac
+done
+
+sudo xargs -a dirs.list -L 1 -I @ find ${SD_DIR%/}@ -type f -print0 | xargs -0 sudo tar cv | gzip -9 > "$OUTPUT"


### PR DESCRIPTION
Linux backup shell script that will backup all pwnagotchi files in a given sd card directory.


## Description
Small script to backup files from a pwnagotchi's SD card. 

## Motivation and Context
Makes it easier to backup the files from a pwnagotchi without needing ssh. Just plug in your pwnaotchi SD card and run the script while specifying the absolute directory of the rootfs folder.

I also have added a separate directory file with the list of important directories. The other backup scripts could use this file in the future allowing a centralized list.
- [x] I have raised an issue to propose this change #745 


## How Has This Been Tested?
Tested with two pwnagotchi micro sd cards
1. Plug in pwnagotchi sd card that has been used before (so that we have files to backup)
2. Mount the micro sd card
3. Find the rootfs direcory ex. /run/media/allie/rootfs
4. run the script with ./sd_backup.sh -d /run/media/allie/rootfs -o test.tar.gz
5. verified all files that are listed in dirs.list have been backed up into test.tar.gz

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
