### PR TITLE
Add scipy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests==2.21.0
 PyYAML==5.1
 scapy==2.4.3
 gym==0.14.0
+scipy==1.3.1
 stable-baselines==2.7.0
 tensorflow==1.13.1
 tensorflow-estimator==1.14.0


### PR DESCRIPTION
We need to add scipy to the requirements.txt. Otherwise it will try to install the newest version, which isn't available on piwheels.org. pip will therefore (try to) compile it, which takes yeeearrs :(