### PR TITLE
Integrate dnsmasq to give DHCP lease on usb0

### DIFF
--- a/builder/data/etc/default/dnsmasq
+++ b/builder/data/etc/default/dnsmasq
@@ -1,0 +1,3 @@
+ENABLED=1
+CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+DNSMASQ_EXCEPT=lo

--- a/builder/data/etc/dnsmasq.conf
+++ b/builder/data/etc/dnsmasq.conf
@@ -1,0 +1,5 @@
+listen-address=10.0.0.2
+dhcp-range=10.0.0.1,10.0.0.1,255.0.0.0,2m
+dhcp-option=3
+dhcp-option=6
+bootp-dynamic

--- a/builder/data/etc/dnsmasq.conf
+++ b/builder/data/etc/dnsmasq.conf
@@ -1,5 +1,5 @@
 listen-address=10.0.0.2
-dhcp-range=10.0.0.1,10.0.0.1,255.0.0.0,2m
+dhcp-range=10.0.0.1,10.0.0.1,255.255.255.0,2m
 dhcp-option=3
 dhcp-option=6
 bootp-dynamic

--- a/builder/pwnagotchi.json
+++ b/builder/pwnagotchi.json
@@ -56,6 +56,16 @@
     },
     {
       "type": "file",
+      "source": "data/etc/default/dnsmasq",
+      "destination": "/etc/default/dnsmasq"
+    },
+    {
+      "type": "file",
+      "source": "data/etc/dnsmasq.conf",
+      "destination": "/etc/dnsmasq.conf"
+    },
+    {
+      "type": "file",
       "source": "data/etc/network/interfaces.d/lo-cfg",
       "destination": "/etc/network/interfaces.d/lo-cfg"
     },

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -103,6 +103,9 @@
           - python3-flask
           - python3-flask-cors
           - python3-flaskext.wtf
+          - dns-root-data
+          - dnsmasq
+          - dnsmasq-base
 
   tasks:
   - name: change hostname


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This references #748 and fixes #481. During the build of the image with packer, dnsmasq will be installed and configured to hand out a DHCP lease to the host with the same settings as is currently configured statically. This negates the need for users to statically configure their IP address when plugging their unit in and booting to manual mode.

## Description
<!--- Describe your changes in detail -->
This commit changes the builder configuration, installing 3 new packages:
  - dns-root-data
  - dnsmasq-base
  - dnsmasq

Additionally 3 configuration files are changed, the `pwnagotchi.json` builder file, which causes the following files to be placed:
  - `/etc/dnsmasq.conf`
  - `/etc/default/dnsmasq`
The second file had to be modified from default in order to preserve current system nameservers in `/etc/resolv.conf`.

The current only issue with this setup is that a user must wait 2 minutes (minimum DHCP lease time) before they can get another DHCP lease with the same IP (since the range is only one address) due to the MAC address change of the ethernet gadget on every reboot. However, using [this community hack from the documetation](https://pwnagotchi.ai/community/#static-rdnis-gadget-to-avoid-reconfiguration-everytime-you-plug-it-to-the-computer) solves the problem entirely.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
This references issue #748 and fixes issue #448 
It is much more convenient to "Plug n' Play" rather than configure statically your network settings, especially multiple times on GNU/Linux systems where MAC address determines unique adapter entity, rather than order on Windows. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this code live on a Raspberry Pi Zero W (Board rev 1.1) both installing packages manually with config files put in place, and flashing built image.
I however cannot test with Travis CI because the current HEAD of this repo fails to build so therefore this PR does too 😞 
Need to merge #746 😉 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
