### PR TITLE
Integrate dnsmasq to offer DHCP lease on USB ethernet

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -103,6 +103,9 @@
           - python3-flask
           - python3-flask-cors
           - python3-flaskext.wtf
+          - dns-root-data
+          - dnsmasq
+          - dnsmasq-base
 
   tasks:
   - name: change hostname
@@ -292,6 +295,27 @@
         if ! /opt/vc/bin/tvservice -s | egrep 'HDMI|DVI'; then
           /opt/vc/bin/tvservice -o
         fi
+
+  - name: add dnsmasq configuration
+    copy:
+      dest: /etc/dnsmasq.d/01-usb0.conf
+      content: |
+        # Disable local DNS as we only need DHCP
+        port=0
+        # Listen on usb0, i.e. ethernet gadget
+        listen-address=10.0.0.2
+        # Ensure IP leased is default route so we can access internet if shared
+        # Renew lease every 2 minutes so when usb0 MAC changes
+        # on reboot, lease expires relatively quickly and client can get IP again
+        dhcp-range=10.0.0.1,10.0.0.1,255.255.255.0,2m
+        # Offer empty default route
+        dhcp-option=3
+        # Offer empty DNS
+        dhcp-option=6
+
+        # BOOTP is not recommended and gives leases FOREVER so
+        # do not enable unless you fix the MAC address of usb0 from changing
+        #bootp-dynamic
 
   - name: create /etc/pwnagotchi folder
     file:

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -376,6 +376,24 @@
       regexp: '(.*)$'
       line: '\1 modules-load=dwc2,g_ether'
 
+  - name: configure static RNDIS gadget (usb0) MAC address
+    blockinfile:
+      path: /etc/rc.local
+      insertbefore: "exit 0"
+      block: |
+        # Fixes the MAC address of the ethernet gadget (usb0) so it
+        # doesn't change. This ensures the user doesn't have to wait
+        # for DHCP lease expiry on reboot or reconnect
+
+        CMDLINE="/boot/cmdline.txt"
+
+        if ! grep -q 'g_ether.host_addr=' $CMDLINE && ! grep -q 'g_ether.dev_addr=' $CMDLINE; then
+          HOST_ADDR='g_ether.host_addr='$(dmesg | awk '/: HOST MAC/{print $NF}')
+          DEV_ADDR='g_ether.dev_addr='$(dmesg | awk '/: MAC/{print $NF}')
+          RNDIS="$HOST_ADDR $DEV_ADDR"
+          sed -i '$ s/$/ \'"$RNDIS"'/' $CMDLINE
+        fi
+
   - name: configure motd
     copy:
       dest: /etc/motd

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -302,12 +302,16 @@
       content: |
         # Disable local DNS as we only need DHCP
         port=0
+        # Ensure we're authoritative, so any requests will get answered without timeout
+        dhcp-authoritative
+        # Do not check if the address is in use, since there is only one address to lease
+        no-ping
+        # Store leasefile in /tmp so it gets cleared on reboot
+        dhcp-leasefile=/tmp/dhcp.leases
         # Listen on usb0, i.e. ethernet gadget
         listen-address=10.0.0.2
         # Ensure IP leased is default route so we can access internet if shared
-        # Renew lease every 2 minutes so when usb0 MAC changes
-        # on reboot, lease expires relatively quickly and client can get IP again
-        dhcp-range=10.0.0.1,10.0.0.1,255.255.255.0,2m
+        dhcp-range=10.0.0.1,10.0.0.1,255.255.255.0,24h
         # Offer empty default route
         dhcp-option=3
         # Offer empty DNS
@@ -383,7 +387,7 @@
       block: |
         # Fixes the MAC address of the ethernet gadget (usb0) so it
         # doesn't change. This ensures the user doesn't have to wait
-        # for DHCP lease expiry on reboot or reconnect
+        # for DHCP lease expiry on reconnect without reboot
 
         CMDLINE="/boot/cmdline.txt"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This references #748 and fixes #481. During the build of the image with packer, dnsmasq will be installed and configured to offer a DHCP lease to a client with the same values as is currently configured statically. This negates the need for users to statically configure their IP address when plugging their unit in and booting to manual mode, i.e everything will Just Work:tm:.

## Description
<!--- Describe your changes in detail -->
This commit changes the builder configuration, installing 3 new packages:
  - dns-root-data
  - dnsmasq-base
  - dnsmasq

Three configuration files are added/changed by adding routines to create/change them in `pwnagotchi.yml`:
  - `/etc/dnsmasq.d/01-usb0.conf`
  - `/etc/default/dnsmasq`
  - `/etc/rc.local`

The defaults file needed to modify in order to preserve system nameservers in `/etc/resolv.conf`.
The `rc.local` file has been appended with a modified version of [this community hack](https://pwnagotchi.ai/community/#static-rdnis-gadget-to-avoid-reconfiguration-everytime-you-plug-it-to-the-computer) so that the RNDIS ethernet gadget's MAC address is fixed from first boot. This ensures that any client will immediately get the same DHCP lease as it appears as the same device.

If the user wants to remove this config, it is simple as editing `/boot/cmdline.txt` and removing the MAC address kernel parameters, and commenting/removing the lines in `rc.local`. In this case, the device is unique on every boot, so DHCP leases will expire every 2 minutes (minimum lease time) in order to ensure a client can reconnect after a reboot/replug relatively quickly.

Statically configuring the network settings is always an option, DHCP can be ignored entirely with no ill effects, it only offers leases if clients broadcast DHCPDISCOVER and statically configured devices do not (or at least should not)..

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
This references issue #748 and fixes issue #448
It is much more convenient to "Plug n' Play" rather than configure statically your network settings, especially multiple times on GNU/Linux systems where MAC address determines unique adapter entity, rather than order on Windows. With dnsmasq we can achieve this with very little overhead, especially with the local DNS server disabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this code live on a Raspberry Pi Zero W (Board rev 1.1) both installing packages manually with config files put in place, and flashing built image using the Makefile with the exact same commands used by Travis CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
