### PR TITLE
Add face expression when uploading to Online Hash Crack

### DIFF
--- a/pwnagotchi/plugins/default/onlinehashcrack.py
+++ b/pwnagotchi/plugins/default/onlinehashcrack.py
@@ -38,6 +38,9 @@ class OnlineHashCrack(plugins.Plugin):
         # remove special characters from whitelist APs to match on-disk format
         self.options['whitelist'] = set(map(lambda x: re.sub(r'[^a-zA-Z0-9]', '', x), self.options['whitelist']))
 
+        if 'face' not in self.options:
+            self.options['face'] = '(>‿‿>)'
+
         self.ready = True
 
     def _filter_handshake_file(self, handshake_filename):
@@ -95,6 +98,7 @@ class OnlineHashCrack(plugins.Plugin):
                     logging.info("OHC: Internet connectivity detected. Uploading new handshakes to onelinehashcrack.com")
 
                     for idx, handshake in enumerate(handshake_new):
+                        display.set('face', self.options['face'])
                         display.set('status',
                                     f"Uploading handshake to onlinehashcrack.com ({idx + 1}/{len(handshake_new)})")
                         display.update(force=True)


### PR DESCRIPTION
Signed-off-by: xBelladonna <isabelladonnamoore@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->
This changes the Online Hash Crack plugin so that a face is displayed when uploading to Online Hash Crack. The face is customizable by setting a `face` key in the plugin config.

## Description
<!--- Describe your changes in detail -->
When the UI is update by the OHC plugin, default face of `(>‿‿>)` is displayed.
This face can be customized by adding a `face` key into the plugin config. On load, plugin will check for this key and use its value for face instead of the hardcoded default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
This references issue #754
It is not intended to solve a problem but merely as aesthetic improvement/to make Pwnagotchi cuter :^)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by cloning my fork to an RPi Zero W (Rev 1.1) running 1.4.3 image and ran `pip3 install .` (after stopping all relevant services). I currently use this codebase in my day to day adventures with my pwnagotchi and after checking logs, handshakes and resultant entries on the OHC website, there appears to be no adverse effects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
