### PR TITLE
fix incorrect dependency for Crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-crypto==1.4.1
+pycryptodome==3.9.4
 requests==2.21.0
 PyYAML==5.1
 scapy==2.4.3


### PR DESCRIPTION
## Description

This resolves #749 by removing the Crypto dependency and replacing it with Pycryptodome - as suggested in the issue.

## Motivation and Context

It gets pwnagotchi one step closer to being able to be built and installed on Linux x86_64 out of the box, and is a simple fix as already documented in #749 

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

By running `pip3 uninstall crypto && pip3 install -r requirements.txt` on a Fedora x86_64 laptop, and then running `pwnagotchi`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
