### PR TITLE
Small UI changes originated from heavy usage at 36c3

### DIFF
--- a/pwnagotchi/ui/hw/waveshare2.py
+++ b/pwnagotchi/ui/hw/waveshare2.py
@@ -17,7 +17,7 @@ class WaveshareV2(DisplayImpl):
             self._layout['face'] = (0, 40)
             self._layout['name'] = (5, 20)
             self._layout['channel'] = (0, 0)
-            self._layout['aps'] = (28, 0)
+            self._layout['aps'] = (35, 0)
             self._layout['uptime'] = (185, 0)
             self._layout['line1'] = [0, 14, 250, 14]
             self._layout['line2'] = [0, 108, 250, 108]
@@ -37,7 +37,7 @@ class WaveshareV2(DisplayImpl):
             self._layout['face'] = (0, 26)
             self._layout['name'] = (5, 15)
             self._layout['channel'] = (0, 0)
-            self._layout['aps'] = (28, 0)
+            self._layout['aps'] = (35, 0)
             self._layout['status'] = (91, 15)
             self._layout['uptime'] = (147, 0)
             self._layout['line1'] = [0, 12, 212, 12]

--- a/pwnagotchi/ui/hw/waveshare2.py
+++ b/pwnagotchi/ui/hw/waveshare2.py
@@ -21,8 +21,7 @@ class WaveshareV2(DisplayImpl):
             self._layout['uptime'] = (185, 0)
             self._layout['line1'] = [0, 14, 250, 14]
             self._layout['line2'] = [0, 108, 250, 108]
-            self._layout['friend_face'] = (0, 92)
-            self._layout['friend_name'] = (40, 94)
+            self._layout['friend_name'] = (0, 92)
             self._layout['shakes'] = (0, 109)
             self._layout['mode'] = (225, 109)
             self._layout['status'] = {
@@ -42,8 +41,7 @@ class WaveshareV2(DisplayImpl):
             self._layout['uptime'] = (147, 0)
             self._layout['line1'] = [0, 12, 212, 12]
             self._layout['line2'] = [0, 92, 212, 92]
-            self._layout['friend_face'] = (0, 76)
-            self._layout['friend_name'] = (40, 78)
+            self._layout['friend_name'] = (0, 76)
             self._layout['shakes'] = (0, 93)
             self._layout['mode'] = (187, 93)
             self._layout['status'] = {

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -40,10 +40,10 @@ class View(object):
         self._width = self._layout['width']
         self._height = self._layout['height']
         self._state = State(state={
-            'channel': LabeledValue(color=BLACK, label='CH', value='00', position=self._layout['channel'],
+            'channel': LabeledValue(color=BLACK, label='CH', value='000', position=self._layout['channel'],
                                     label_font=fonts.Bold,
                                     text_font=fonts.Medium),
-            'aps': LabeledValue(color=BLACK, label='APS', value='0 (00)', position=self._layout['aps'],
+            'aps': LabeledValue(color=BLACK, label='APs', value='0 (00)', position=self._layout['aps'],
                                 label_font=fonts.Bold,
                                 text_font=fonts.Medium),
 
@@ -56,8 +56,8 @@ class View(object):
 
             'face': Text(value=faces.SLEEP, position=self._layout['face'], color=BLACK, font=fonts.Huge),
 
-            'friend_face': Text(value=None, position=self._layout['friend_face'], font=fonts.Bold, color=BLACK),
-            'friend_name': Text(value=None, position=self._layout['friend_name'], font=fonts.BoldSmall,
+            # 'friend_face': Text(value=None, position=self._layout['friend_face'], font=fonts.Bold, color=BLACK),
+            'friend_name': Text(value=None, position=self._layout['friend_face'], font=fonts.BoldSmall,
                                 color=BLACK),
 
             'name': Text(value='%s>' % 'pwnagotchi', position=self._layout['name'], color=BLACK, font=fonts.Bold),

--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -56,8 +56,7 @@ class View(object):
 
             'face': Text(value=faces.SLEEP, position=self._layout['face'], color=BLACK, font=fonts.Huge),
 
-            # 'friend_face': Text(value=None, position=self._layout['friend_face'], font=fonts.Bold, color=BLACK),
-            'friend_name': Text(value=None, position=self._layout['friend_face'], font=fonts.BoldSmall,
+            'friend_name': Text(value=None, position=self._layout['friend_name'], font=fonts.BoldSmall,
                                 color=BLACK),
 
             'name': Text(value='%s>' % 'pwnagotchi', position=self._layout['name'], color=BLACK, font=fonts.Bold),
@@ -183,7 +182,6 @@ class View(object):
 
     def set_closest_peer(self, peer, num_total):
         if peer is None:
-            self.set('friend_face', None)
             self.set('friend_name', None)
         else:
             # ref. https://www.metageek.com/training/resources/understanding-rssi-2.html
@@ -206,7 +204,6 @@ class View(object):
                 else:
                     name += ' of %d' % num_total
 
-            self.set('friend_face', peer.face())
             self.set('friend_name', name)
         self.update()
 

--- a/pwnagotchi/ui/web/handler.py
+++ b/pwnagotchi/ui/web/handler.py
@@ -126,6 +126,9 @@ class Handler:
             logging.exception('error while reading pwngrid peers')
             error = str(e)
 
+        # put last seen friends on top
+        peers.sort(key=lambda peer: peer['seen_at'], reverse=True)
+
         return render_template('peers.html',
                                name=pwnagotchi.name(),
                                peers=peers,

--- a/pwnagotchi/ui/web/templates/peers.html
+++ b/pwnagotchi/ui/web/templates/peers.html
@@ -12,7 +12,8 @@
         <a href="/inbox/new?to={{ peer.fingerprint }}">
             <h2>{{ peer.advertisement.face }} {{ peer.advertisement.name }}@{{ peer.fingerprint }}</h2>
             <p>
-                Pwned {{ peer.advertisement.pwnd_tot }} networks, {{ peer.encounters }} encounters.
+                Pwned {{ peer.advertisement.pwnd_tot }} networks, {{ peer.encounters }} encounters{% if peer.seen_at %}, seen
+                <b><time class="timeago" datetime="{{ peer.seen_at }}">{{ peer.seen_at }}</time></b>{% endif %}.
             </p>
         </a>
     </li>


### PR DESCRIPTION
...but seem also reasonable for normal everyday usage :)

## Description
* Make space for 5ghz channels (could be 3 instead of 2 digits)
* Remove the face of peers - i dont get value from it and with gps enabled theres is simply not enough space to show the "... of 9" part of the peer line - which is much more interesting for me than the face of another gotchi
* sort peers in web-ui with the peer we just met at the top
* show time when we saw a peer last time in "peers" (like already done in "inbox")

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Yes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
