### PR TITLE
Add PACKER_VERSION to Makefile, bump packer to 1.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+PACKER_VERSION=1.4.5
 PWN_HOSTNAME=pwnagotchi
 PWN_VERSION=master
 
 all: clean install image
 
 install:
-	curl https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip -o /tmp/packer.zip
+	curl https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_linux_amd64.zip -o /tmp/packer.zip
 	unzip /tmp/packer.zip -d /tmp
 	sudo mv /tmp/packer /usr/bin/packer
 	git clone https://github.com/solo-io/packer-builder-arm-image /tmp/packer-builder-arm-image


### PR DESCRIPTION

## Description
As in title, also packer 1.5+ is not yet supported by the packer-builder, but this is a WIP, see:
https://github.com/solo-io/packer-builder-arm-image/issues/41

## Motivation and Context
It makes Packer easier to maintain.
#766
- [x] I have raised an issue to propose this change

## How Has This Been Tested?
make install

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

Signed-off-by: foreign-sub <51928805+foreign-sub@users.noreply.github.com>
