### PR TITLE
add gpsdaemon plugin

### DIFF
--- a/pwnagotchi/defaults.yml
+++ b/pwnagotchi/defaults.yml
@@ -29,6 +29,10 @@ main:
             enabled: false
             speed: 19200
             device: /dev/ttyUSB0
+        gpsdaemon:
+            enabled: false
+            host: "localhost"
+            port: 2947
         webgpsmap:
             enabled: false
         onlinehashcrack:

--- a/pwnagotchi/plugins/default/gpsdaemon.py
+++ b/pwnagotchi/plugins/default/gpsdaemon.py
@@ -1,0 +1,124 @@
+import json
+import logging
+import os
+
+import pwnagotchi.plugins as plugins
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.components import LabeledValue
+from pwnagotchi.ui.view import BLACK
+
+
+class GPSDaemon(plugins.Plugin):
+    __author__ = "fheylis (https://github.com/fheylis)"
+    __version__ = "1.0.0"
+    __license__ = "GPL3"
+    __description__ = "Save GPS coordinates from GPSD whenever an handshake is captured."
+
+    def __init__(self):
+        self.running = False
+        self.coordinates = None
+
+    def on_loaded(self):
+        logging.info(f"[gpsdaemon] plugin loaded for {self.options['host']}:{self.options['port']}")
+
+    def on_ready(self, agent):
+        logging.info(f"[gpsdaemon] enabling bettercap's gpsdaemon module for {self.options['host']}:{self.options['port']}")
+
+        agent.run(f"set gpsdaemon.host {self.options['host']}")
+        agent.run(f"set gpsdaemon.port {self.options['port']}")
+        agent.run("gpsdaemon on")
+        self.running = True
+
+    def on_handshake(self, agent, filename, access_point, client_station):
+        if self.running:
+            info = agent.session()
+            self.coordinates = info["gps"]
+            gps_filename = filename.replace(".pcap", ".gps.json")
+
+            logging.info(f"[gpsdaemon] saving GPS to {gps_filename} ({self.coordinates})")
+            with open(gps_filename, "w+t") as fp:
+                json.dump(self.coordinates, fp)
+
+    def on_ui_setup(self, ui):
+        # add coordinates for other displays
+        if ui.is_waveshare_v2():
+            lat_pos = (127, 75)
+            lon_pos = (122, 84)
+            alt_pos = (127, 94)
+        elif ui.is_waveshare_v1():
+            lat_pos = (130, 70)
+            lon_pos = (125, 80)
+            alt_pos = (130, 90)
+        elif ui.is_inky():
+            # guessed values, add tested ones if you can
+            lat_pos = (112, 30)
+            lon_pos = (112, 49)
+            alt_pos = (87, 63)
+        elif ui.is_waveshare144lcd():
+            # guessed values, add tested ones if you can
+            lat_pos = (67, 73)
+            lon_pos = (62, 83)
+            alt_pos = (67, 93)
+        else:
+            # guessed values, add tested ones if you can
+            lat_pos = (127, 51)
+            lon_pos = (127, 56)
+            alt_pos = (102, 71)
+
+        label_spacing = 0
+
+        ui.add_element(
+            "latitude",
+            LabeledValue(
+                color=BLACK,
+                label="lat:",
+                value="-",
+                position=lat_pos,
+                label_font=fonts.Small,
+                text_font=fonts.Small,
+                label_spacing=label_spacing,
+            ),
+        )
+        ui.add_element(
+            "longitude",
+            LabeledValue(
+                color=BLACK,
+                label="long:",
+                value="-",
+                position=lon_pos,
+                label_font=fonts.Small,
+                text_font=fonts.Small,
+                label_spacing=label_spacing,
+            ),
+        )
+        ui.add_element(
+            "altitude",
+            LabeledValue(
+                color=BLACK,
+                label="alt:",
+                value="-",
+                position=alt_pos,
+                label_font=fonts.Small,
+                text_font=fonts.Small,
+                label_spacing=label_spacing,
+            ),
+        )
+
+
+    def on_unload(self, ui):
+        with ui._lock:
+            ui.remove_element('latitude')
+            ui.remove_element('longitude')
+            ui.remove_element('altitude')
+
+
+    def on_ui_update(self, ui):
+        if self.coordinates and all([
+            # avoid 0.000... measurements
+            self.coordinates["Latitude"], self.coordinates["Longitude"]
+        ]):
+            # last char is sometimes not completely drawn
+            # using an ending-whitespace as workaround on each line
+            ui.set("latitude", f"{self.coordinates['Latitude']:.4f} ")
+            ui.set("longitude", f" {self.coordinates['Longitude']:.4f} ")
+            ui.set("altitude", f" {self.coordinates['Altitude']:.1f}m ")

--- a/pwnagotchi/plugins/default/gpsdaemon.py
+++ b/pwnagotchi/plugins/default/gpsdaemon.py
@@ -12,7 +12,7 @@ class GPSDaemon(plugins.Plugin):
     __author__ = "fheylis (https://github.com/fheylis)"
     __version__ = "1.0.0"
     __license__ = "GPL3"
-    __description__ = "Save GPS coordinates from GPSD whenever an handshake is captured."
+    __description__ = "Save GPS coordinates from GPSD whenever a handshake is captured."
 
     def __init__(self):
         self.running = False


### PR DESCRIPTION
## Description
This plugin configures bettercap to interface with gpsd for gps data instead of a gps devices serial port directly. This is done to be able to share gps time data from gpsd to ntpd or chrony for devices that don't have a RTC or a network connection (like the raspi 0 w).

This requires https://github.com/bettercap/bettercap/pull/680

This plugin could alternatively be integrated into gps.py and be toggleable via a config flag, but since this is the first time I'm writing something in python (just like the bettercap module was my first time with go) I decided it would be best to just do it this way for now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is a direct fork of the original gps plugin with just minor changes and was tested on my pwnagotchi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
