### PR TITLE
Prevents permanent tfevent files

### DIFF
--- a/builder/data/etc/systemd/system/pwnagotchi.service
+++ b/builder/data/etc/systemd/system/pwnagotchi.service
@@ -6,6 +6,7 @@ After=pwngrid-peer.service
 
 [Service]
 Type=simple
+WorkingDirectory=/tmp
 PermissionsStartOnly=true
 ExecStart=/usr/bin/pwnagotchi-launcher
 Restart=always


### PR DESCRIPTION
Fix #762 

This should fix the mentioned issue. The files will still be created, but under /tmp, which will be cleaned after reboot.