### PR TITLE
Use "sys.exit" instead of "exit" builtin

### DIFF
--- a/bin/pwnagotchi
+++ b/bin/pwnagotchi
@@ -4,6 +4,7 @@ import argparse
 import time
 import yaml
 import signal
+import sys
 
 import pwnagotchi
 import pwnagotchi.grid as grid
@@ -19,7 +20,7 @@ from pwnagotchi import restart
 def do_clear(display):
     logging.info("clearing the display ...")
     display.clear()
-    exit(0)
+    sys.exit(0)
 
 
 def do_manual_mode(agent):
@@ -115,12 +116,12 @@ if __name__ == '__main__':
 
     if args.version:
         print(pwnagotchi.version)
-        exit(0)
+        sys.exit(0)
 
     config = utils.load_config(args)
     if args.print_config:
         print(toml.dumps(config))
-        exit(0)
+        sys.exit(0)
 
     utils.setup_logging(args, config)
 
@@ -132,7 +133,7 @@ if __name__ == '__main__':
 
     if args.do_clear:
         do_clear(display)
-        exit(0)
+        sys.exit(0)
 
     agent = Agent(view=display, config=config, keypair=KeyPair(view=display))
 

--- a/pwnagotchi/ui/hw/libs/dfrobot/dfrobot_epaper.py
+++ b/pwnagotchi/ui/hw/libs/dfrobot/dfrobot_epaper.py
@@ -11,7 +11,7 @@ try:
   from .gpio import GPIO
 except:
   print("unknown platform")
-  exit()
+  sys.exit()
 
 CONFIG_IL0376F = {
 

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -13,6 +13,7 @@ import gzip
 import contextlib
 import tempfile
 import toml
+import sys
 
 import pwnagotchi
 
@@ -92,7 +93,7 @@ def load_config(args):
             config = merge_config(user_config, config)
     except Exception as ex:
         logging.error("There was an error processing the configuration file:\n%s ",ex)
-        exit(1)
+        sys.exit(1)
 
     # the very first step is to normalize the display name so we don't need dozens of if/elif around
     if config['ui']['display']['type'] in ('inky', 'inkyphat'):
@@ -139,7 +140,7 @@ def load_config(args):
 
     else:
         print("unsupported display type %s" % config['ui']['display']['type'])
-        exit(1)
+        sys.exit(1)
 
     return config
 


### PR DESCRIPTION
## Description
This resolves #789 by replacing all `exit` builtins with `sys.exit`.

## Motivation and Context
According to the [Python documentation](https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module), it is best practice to use `sys.exit` and avoid errors in programs such as PyInstaller (pyinstaller/pyinstaller#1687).
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
By running `pip3 install -r requirements.txt` on a Raspbian 10 Docker container and then running `pwnagotchi`.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
