### PR TITLE
Allow installer deactivation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
+from distutils.util import strtobool
 import os
 import glob
 import shutil
@@ -43,7 +44,8 @@ def installer():
     os.system("systemctl enable fstrim.timer")
 
 
-installer()
+if strtobool(os.environ.get("PWNAGOTCHI_ENABLE_INSTALLER", "1")):
+    installer()
 
 with open('requirements.txt') as fp:
     required = [line.strip() for line in fp if line.strip() != ""]


### PR DESCRIPTION
## Description
This resolves #794 by reading and using the `PWNAGOTCHI_ENABLE_INSTALLER` environment variable in `setup.py`.

## Motivation and Context
In some cases you want to install Pwnagotchi without making any modifications to the system, for example while being inside a virtual environment.
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
By running `pip3 install ./` with the `PWNAGOTCHI_ENABLE_INSTALLER` environment variable with values `true`, `false` and unset and observing that the behavior is as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
