### PR TITLE
Prevent saving gps file without coordinates

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -44,9 +44,15 @@ class GPS(plugins.Plugin):
             self.coordinates = info["gps"]
             gps_filename = filename.replace(".pcap", ".gps.json")
 
-            logging.info(f"saving GPS to {gps_filename} ({self.coordinates})")
-            with open(gps_filename, "w+t") as fp:
-                json.dump(self.coordinates, fp)
+            if self.coordinates and all([
+                # avoid 0.000... measurements
+                self.coordinates["Latitude"], self.coordinates["Longitude"]
+            ]):
+                logging.info(f"saving GPS to {gps_filename} ({self.coordinates})")
+                with open(gps_filename, "w+t") as fp:
+                    json.dump(self.coordinates, fp)
+            else:
+                logging.info("not saving GPS. Couldn't find location.")
 
     def on_ui_setup(self, ui):
         # add coordinates for other displays


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the gps plugin creates a .gps file even if no coordinates are found. This PR prevents this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
See https://github.com/evilsocket/pwnagotchi/issues/761

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it locally. Works for me.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
