### PR TITLE
Fix hardware display startup sequence

### DIFF
--- a/pwnagotchi/ui/view.py
+++ b/pwnagotchi/ui/view.py
@@ -138,6 +138,7 @@ class View(object):
     def on_starting(self):
         self.set('status', self._voice.on_starting() + ("\n(v%s)" % pwnagotchi.__version__))
         self.set('face', faces.AWAKE)
+        self.update()
 
     def on_ai_ready(self):
         self.set('mode', '  AI')


### PR DESCRIPTION
Signed-off-by: xBelladonna <isabelladonnamoore@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->
Fixes the display startup sequence bug described in #814

## Description
<!--- Describe your changes in detail -->
Triggers an update of the UI which appeared to be missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
Described in issue #814


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested live on a pwnagotchi running a 1.4.3 image on a Raspberry Pi Zero W with a Waveshare v2 display. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
