### PR TITLE
Fix typo in systemd service to disable journal logging

### DIFF
--- a/builder/data/etc/systemd/system/pwnagotchi.service
+++ b/builder/data/etc/systemd/system/pwnagotchi.service
@@ -13,8 +13,8 @@ Restart=always
 RestartSec=30
 TasksMax=infinity
 LimitNPROC=infinity
-StandartOutput=null
-StandartError=null
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description
Fixes #823 where typo causes journal logging still being enabled. Simply changes the systemd unit for pwnagotchi, fixing typo in `StandardOutput` and `StandardError` directives.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
23616095baa043fc8029bde327e175d5f4e4afe7 was pushed to disable journal logging but there was typos, therefore journal logging continues on newly build/flashed images.
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
Fixes #823


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested live on fresh pwnagotchi v1.4.3 image on a Pi0W with a Waveshare v2 e-paper hat.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
