### PR TITLE
Disable deauth and PMKID attacks by default

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -129,8 +129,8 @@ ai.params.verbose = 1
 ai.params.lr_schedule = "constant"
 
 personality.advertise = true
-personality.deauth = true
-personality.associate = true
+personality.deauth = false
+personality.associate = false
 personality.channels = []
 personality.min_rssi = -200
 personality.ap_ttl = 120


### PR DESCRIPTION
## Description

The deauth and PMKID attacks can be disruptive and possibly illegal in some circumstances. It should not be enabled by default.

## Motivation and Context

Devices have been observed in the wild causing disruption. The deauth behaviour is particularly disruptive and the memory of seen clients may be too small. If someone wants to run this, they should explicitly choose to do so. 