### PR TITLE
Fix for gps labels on inkyphat displays

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -59,10 +59,9 @@ class GPS(plugins.Plugin):
             lon_pos = (125, 80)
             alt_pos = (130, 90)
         elif ui.is_inky():
-            # guessed values, add tested ones if you can
-            lat_pos = (112, 30)
-            lon_pos = (112, 49)
-            alt_pos = (87, 63)
+            lat_pos = (127, 60)
+            lon_pos = (127, 70)
+            alt_pos = (127, 80)
         elif ui.is_waveshare144lcd():
             # guessed values, add tested ones if you can
             lat_pos = (67, 73)


### PR DESCRIPTION
Positioned the gps labels correctly on inkyphat displays

## Description
Positioned the gps labels correctly on inkyphat displays, as they were positioned too far left and high up which overlapped with the standard pwnagotchi output.

## Motivation and Context
Fixed GPS labels overlapping with standard pwnagotchi output.

## How Has This Been Tested?
Tested on my own pwnagotchi with an inkyphat display and GPS module running latest.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
