### PR TITLE
Display coordinates for dfrobotv2

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -73,6 +73,10 @@ class GPS(plugins.Plugin):
             lat_pos = (67, 73)
             lon_pos = (62, 83)
             alt_pos = (67, 93)
+        elif ui.is_dfrobot_v2: 
+            lat_pos = (127, 75)
+            lon_pos = (122, 84)
+            alt_pos = (127, 94)
         else:
             # guessed values, add tested ones if you can
             lat_pos = (127, 51)


### PR DESCRIPTION
## Description
Coordinates for dfrobot v2 screens. If not lat, long, and alt are not displayed in the right locations.

## Motivation and Context
This solves the issue of not displaying GPS info in the right location of the screen.

## How Has This Been Tested?
Made the changes. Ran `sudo pip3 install .` and restarted the pwnagotchi service. Fields are in a way better location than they were before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
