### PR TITLE
Delaying fs sync to ensure shutdown message is logged to disk

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -106,12 +106,6 @@ def temperature(celsius=True):
 
 
 def shutdown():
-    logging.warning("syncing...")
-
-    from pwnagotchi import fs
-    for m in fs.mounts:
-        m.sync()
-
     logging.warning("shutting down ...")
 
     from pwnagotchi.ui import view
@@ -119,6 +113,13 @@ def shutdown():
         view.ROOT.on_shutdown()
         # give it some time to refresh the ui
         time.sleep(10)
+
+    logging.warning("syncing...")
+
+    from pwnagotchi import fs
+    for m in fs.mounts:
+        m.sync()
+ 
     os.system("sync")
     os.system("halt")
 


### PR DESCRIPTION
Delay filesystem sync until just before shutdown so that "shutting down ..." message is logged to disk when memory caching is enabled.

Fixes #871 

## Description
Moved fs.mounts sync() loop until just before shutdown halt occurs.

## Motivation and Context
- [x] I have raised an issue to propose this change: https://github.com/evilsocket/pwnagotchi/issues/871

## How Has This Been Tested?
Tested on my RPi0 pwnagotchi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`