### PR TITLE
Ensure fs is synced before reboot so logs aren't lost

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -153,5 +153,11 @@ def reboot(mode=None):
     elif mode == 'MANU':
         os.system("touch /root/.pwnagotchi-manual")
 
+    logging.warning("syncing...")
+
+    from pwnagotchi import fs
+    for m in fs.mounts:
+        m.sync()
+
     os.system("sync")
     os.system("shutdown -r now")


### PR DESCRIPTION
Sync filesystem memory cache before reboot so that logs and other memory-cached filesystem changes aren't lost.

Fixes #873

## Description
Copied code from shutdown subroutine so that fs.mounts are synced prior to system reboot.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change: https://github.com/evilsocket/pwnagotchi/issues/873

## How Has This Been Tested?
Tested on my RPi0 pwnagotchi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`