### PR TITLE
Have watchdog plugin reboot system rather than restart application

### DIFF
--- a/pwnagotchi/plugins/default/watchdog.py
+++ b/pwnagotchi/plugins/default/watchdog.py
@@ -33,4 +33,4 @@ class Watchdog(plugins.Plugin):
             logging.info('[WATCHDOG] Blind-Bug detected. Restarting.')
             mode = 'MANU' if agent.mode == 'manual' else 'AUTO'
             import pwnagotchi
-            pwnagotchi.restart(mode=mode)
+            pwnagotchi.reboot(mode=mode)


### PR DESCRIPTION
The watchdog plugin detects the blindbug and restarts the application to fix the problem. Unfortunately its detection method relies on the kernel log changing so it doesn't constantly detect the blindbug. Rebooting the system instead of just restarting the application ensures that the kernel log is cleared.

Rebooting might also provide a better fix for the blindbug but this hasn't been tested.

Fixes #875

## Description
Replace call to pwnagotchi.restart with pwnagotchi.reboot.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change: https://github.com/evilsocket/pwnagotchi/issues/875

## How Has This Been Tested?
Tested on my RPi0 pwnagotchi.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`