### PR TITLE
If a step fails, abort script.

### DIFF
--- a/scripts/linux_connection_share.sh
+++ b/scripts/linux_connection_share.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # name of the ethernet gadget interface on the host
 USB_IFACE=${1:-enp0s20f0u1}


### PR DESCRIPTION
added a line to linux script to stop running the scripts in the event that any line returns a non-zero status

## Description
added a line to linux script that stops running the scripts in the event that any line returns a non-zero status

## Motivation and Context
This change helps prevent invoking changes to iptables if something is wrong ahead of time

- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I have run this script while not understanding what it does.  The first argument gets set as USB_IFACE.  When line 14 (`ip addr add "$USB_IFACE_IP/24" dev "$USB_IFACE"`) fails, then the subsequent lines are not run.  This is desireable b/c the next lines include altering iptables rules.
https://www.howtogeek.com/668503/how-to-set-environment-variables-in-bash-on-linux/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
