### PR TITLE
Make sure IPv4 works when eth0 is connected

### DIFF
--- a/builder/data/etc/network/interfaces.d/usb0-cfg
+++ b/builder/data/etc/network/interfaces.d/usb0-cfg
@@ -5,3 +5,4 @@ iface usb0 inet static
   network 10.0.0.0
   broadcast 10.0.0.255
   gateway 10.0.0.1
+  metric 20


### PR DESCRIPTION
Resolves an issue where IPv4 traffic would not work when eth0 is connected (i.e. usb-ethernet adapter over OTG). The static route for usb0 precedes the DHCP route for eth0. Only IPv6 traffic would work, but not IPv4 until the metric for usb0 is increase and thus lowered in priority. If no eth0 is plugged in, internet works fine over usb0.

## Description
Add metric 20 to usb0

## Motivation and Context
fixes https://github.com/evilsocket/pwnagotchi/issues/908
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Edited on a running RPi W. Without the change IPv4 ping does not work. With the added line and after a reboot, IPv4 ping works. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s` 

