### PR TITLE
Add configuration options to memtemp.py (fields, position, vertical line spacing)

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -57,7 +57,7 @@ class GPS(plugins.Plugin):
     def on_ui_setup(self, ui):
         # add coordinates for other displays
         if ui.is_waveshare_v2():
-            lat_pos = (127, 75)
+            lat_pos = (127, 74)
             lon_pos = (122, 84)
             alt_pos = (127, 94)
         elif ui.is_waveshare_v1():
@@ -66,21 +66,21 @@ class GPS(plugins.Plugin):
             alt_pos = (130, 90)
         elif ui.is_inky():
             lat_pos = (127, 60)
-            lon_pos = (127, 70)
+            lon_pos = (122, 70)
             alt_pos = (127, 80)
         elif ui.is_waveshare144lcd():
             # guessed values, add tested ones if you can
             lat_pos = (67, 73)
             lon_pos = (62, 83)
             alt_pos = (67, 93)
-        elif ui.is_dfrobot_v2: 
-            lat_pos = (127, 75)
+        elif ui.is_dfrobot_v2():
+            lat_pos = (127, 74)
             lon_pos = (122, 84)
             alt_pos = (127, 94)
         elif ui.is_waveshare27inch():
-            lat_pos = (6,120)
-            lon_pos = (1,135)
-            alt_pos = (6,150)
+            lat_pos = (6, 120)
+            lon_pos = (1, 135)
+            alt_pos = (6, 150)
         else:
             # guessed values, add tested ones if you can
             lat_pos = (127, 51)
@@ -126,7 +126,6 @@ class GPS(plugins.Plugin):
             ),
         )
 
-
     def on_unload(self, ui):
         with ui._lock:
             ui.remove_element('latitude')
@@ -141,5 +140,5 @@ class GPS(plugins.Plugin):
             # last char is sometimes not completely drawn ¯\_(ツ)_/¯
             # using an ending-whitespace as workaround on each line
             ui.set("latitude", f"{self.coordinates['Latitude']:.4f} ")
-            ui.set("longitude", f" {self.coordinates['Longitude']:.4f} ")
-            ui.set("altitude", f" {self.coordinates['Altitude']:.1f}m ")
+            ui.set("longitude", f"{self.coordinates['Longitude']:.4f} ")
+            ui.set("altitude", f"{self.coordinates['Altitude']:.1f}m ")

--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -10,7 +10,7 @@ from pwnagotchi.ui.view import BLACK
 
 class GPS(plugins.Plugin):
     __author__ = "evilsocket@gmail.com"
-    __version__ = "1.0.0"
+    __version__ = "1.0.1"
     __license__ = "GPL3"
     __description__ = "Save GPS coordinates whenever an handshake is captured."
 

--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -10,7 +10,7 @@ from pwnagotchi.ui.view import BLACK
 
 class GPS(plugins.Plugin):
     __author__ = "evilsocket@gmail.com"
-    __version__ = "1.0.1"
+    __version__ = "1.0.0"
     __license__ = "GPL3"
     __description__ = "Save GPS coordinates whenever an handshake is captured."
 
@@ -57,7 +57,7 @@ class GPS(plugins.Plugin):
     def on_ui_setup(self, ui):
         # add coordinates for other displays
         if ui.is_waveshare_v2():
-            lat_pos = (127, 74)
+            lat_pos = (127, 75)
             lon_pos = (122, 84)
             alt_pos = (127, 94)
         elif ui.is_waveshare_v1():
@@ -66,21 +66,21 @@ class GPS(plugins.Plugin):
             alt_pos = (130, 90)
         elif ui.is_inky():
             lat_pos = (127, 60)
-            lon_pos = (122, 70)
+            lon_pos = (127, 70)
             alt_pos = (127, 80)
         elif ui.is_waveshare144lcd():
             # guessed values, add tested ones if you can
             lat_pos = (67, 73)
             lon_pos = (62, 83)
             alt_pos = (67, 93)
-        elif ui.is_dfrobot_v2():
-            lat_pos = (127, 74)
+        elif ui.is_dfrobot_v2: 
+            lat_pos = (127, 75)
             lon_pos = (122, 84)
             alt_pos = (127, 94)
         elif ui.is_waveshare27inch():
-            lat_pos = (6, 120)
-            lon_pos = (1, 135)
-            alt_pos = (6, 150)
+            lat_pos = (6,120)
+            lon_pos = (1,135)
+            alt_pos = (6,150)
         else:
             # guessed values, add tested ones if you can
             lat_pos = (127, 51)
@@ -126,6 +126,7 @@ class GPS(plugins.Plugin):
             ),
         )
 
+
     def on_unload(self, ui):
         with ui._lock:
             ui.remove_element('latitude')
@@ -140,5 +141,5 @@ class GPS(plugins.Plugin):
             # last char is sometimes not completely drawn ¯\_(ツ)_/¯
             # using an ending-whitespace as workaround on each line
             ui.set("latitude", f"{self.coordinates['Latitude']:.4f} ")
-            ui.set("longitude", f"{self.coordinates['Longitude']:.4f} ")
-            ui.set("altitude", f"{self.coordinates['Altitude']:.1f}m ")
+            ui.set("longitude", f" {self.coordinates['Longitude']:.4f} ")
+            ui.set("altitude", f" {self.coordinates['Altitude']:.1f}m ")

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -27,7 +27,7 @@ import logging
 
 class MemTemp(plugins.Plugin):
     __author__ = 'https://github.com/xenDE'
-    __version__ = '1.0.1'
+    __version__ = '1.0.2'
     __license__ = 'GPL3'
     __description__ = 'A plugin that will display memory/cpu usage and temperature'
 

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -143,7 +143,7 @@ class MemTemp(plugins.Plugin):
                 )
         else:
             # default to horizontal
-            h_pos_x = h_pos[0]
+            h_pos_x = h_pos[0] + ((len(self.fields) - 3) * -1 * 25)
             h_pos_y = h_pos[1]
             ui.add_element(
                 'memtemp_header',

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -17,7 +17,7 @@
 # - Added horizontal and vertical orientation
 #
 ###############################################################
-from pwnagotchi.ui.components import LabeledValue
+from pwnagotchi.ui.components import LabeledValue, Text
 from pwnagotchi.ui.view import BLACK
 import pwnagotchi.ui.fonts as fonts
 import pwnagotchi.plugins as plugins
@@ -40,39 +40,118 @@ class MemTemp(plugins.Plugin):
     def cpu_load(self):
         return int(pwnagotchi.cpu_load() * 100)
 
+    @staticmethod
+    def pad_text(width, data, symbol):
+        data = str(data) + symbol
+        return " " * (width - len(data)) + data
+
     def on_ui_setup(self, ui):
         if ui.is_waveshare_v2():
-            h_pos = (180, 80)
-            v_pos = (180, 61)
+            h_pos_line1 = (178, 84)
+            h_pos_line2 = (178, 94)
+            v_pos_line1 = (202, 74)  # (127, 75)
+            v_pos_line2 = (202, 84)  # (122, 84)
+            v_pos_line3 = (197, 94)  # (127, 94)
         elif ui.is_waveshare_v1():
-            h_pos = (170, 80)
-            v_pos = (170, 61)
+            h_pos_line1 = (170, 80)
+            h_pos_line2 = (170, 90)
+            v_pos_line1 = (170, 61)  # (130, 70)
+            v_pos_line2 = (170, 71)  # (125, 80)
+            v_pos_line3 = (165, 81)  # (130, 90)
         elif ui.is_waveshare144lcd():
-            h_pos = (53, 77)
-            v_pos = (78, 67)
+            h_pos_line1 = (53, 77)
+            h_pos_line2 = (53, 87)
+            v_pos_line1 = (78, 67)  # (67, 73)
+            v_pos_line2 = (78, 77)  # (62, 83)
+            v_pos_line3 = (73, 87)  # (67, 93)
         elif ui.is_inky():
-            h_pos = (140, 68)
-            v_pos = (165, 54)
+            h_pos_line1 = (140, 68)
+            h_pos_line2 = (140, 78)
+            v_pos_line1 = (165, 54)  # (127, 60)
+            v_pos_line2 = (165, 64)  # (122, 70)
+            v_pos_line3 = (160, 74)  # (127, 80)
         elif ui.is_waveshare27inch():
-            h_pos = (192, 138)
-            v_pos = (216, 122)
+            h_pos_line1 = (192, 138)
+            h_pos_line2 = (192, 148)
+            v_pos_line1 = (216, 122)  # (6,120)
+            v_pos_line2 = (216, 132)  # (1,135)
+            v_pos_line3 = (211, 142)  # (6,150)
         else:
-            h_pos = (155, 76)
-            v_pos = (180, 61)
+            h_pos_line1 = (155, 76)
+            h_pos_line2 = (155, 86)
+            v_pos_line1 = (180, 61)  # (127, 51)
+            v_pos_line2 = (180, 71)  # (127, 56)
+            v_pos_line3 = (175, 81)  # (102, 71)
+
+        label_spacing = 0
 
         if self.options['orientation'] == "vertical":
-            ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value=' mem:-\n cpu:-\ntemp:-',
-                                                   position=v_pos,
-                                                   label_font=fonts.Small, text_font=fonts.Small))
+            ui.add_element(
+                'memtemp_line1',
+                LabeledValue(
+                    color=BLACK,
+                    label='mem:',
+                    value='-',
+                    position=v_pos_line1,
+                    label_font=fonts.Small,
+                    text_font=fonts.Small,
+                    label_spacing=label_spacing,
+                )
+            )
+            ui.add_element(
+                'memtemp_line2',
+                LabeledValue(
+                    color=BLACK,
+                    label='cpu:',
+                    value='-',
+                    position=v_pos_line2,
+                    label_font=fonts.Small,
+                    text_font=fonts.Small,
+                    label_spacing=label_spacing,
+                )
+            )
+            ui.add_element(
+                'memtemp_line3',
+                LabeledValue(
+                    color=BLACK,
+                    label='temp:',
+                    value='-',
+                    position=v_pos_line3,
+                    label_font=fonts.Small,
+                    text_font=fonts.Small,
+                    label_spacing=label_spacing,
+                )
+            )
         else:
             # default to horizontal
-            ui.add_element('memtemp', LabeledValue(color=BLACK, label='', value='mem cpu temp\n - -  -',
-                                                   position=h_pos,
-                                                   label_font=fonts.Small, text_font=fonts.Small))
+            ui.add_element(
+                'memtemp_line1',
+                Text(
+                    color=BLACK,
+                    value=' mem  cpu temp',
+                    position=h_pos_line1,
+                    font=fonts.Small,
+                )
+            )
+            ui.add_element(
+                'memtemp_line2',
+                Text(
+                    color=BLACK,
+                    value='   -    -    -',
+                    position=h_pos_line2,
+                    font=fonts.Small,
+                )
+            )
 
     def on_unload(self, ui):
         with ui._lock:
-            ui.remove_element('memtemp')
+            if self.options['orientation'] == "vertical":
+                ui.remove_element('memtemp_line1')
+                ui.remove_element('memtemp_line2')
+                ui.remove_element('memtemp_line3')
+            else:
+                ui.remove_element('memtemp_line1')
+                ui.remove_element('memtemp_line2')
 
     def on_ui_update(self, ui):
         if self.options['scale'] == "fahrenheit":
@@ -87,9 +166,14 @@ class MemTemp(plugins.Plugin):
             symbol = "c"
 
         if self.options['orientation'] == "vertical":
-            ui.set('memtemp',
-                   " mem:%s%%\n cpu:%s%%\ntemp:%s%s" % (self.mem_usage(), self.cpu_load(), temp, symbol))
+            ui.set('memtemp_line1', f"{self.mem_usage()}%")
+            ui.set('memtemp_line2', f"{self.cpu_load()}%")
+            ui.set('memtemp_line3', f"{temp}{symbol}")
         else:
             # default to horizontal
-            ui.set('memtemp',
-                   " mem cpu temp\n %s%% %s%%  %s%s" % (self.mem_usage(), self.cpu_load(), temp, symbol))
+            ui.set(
+                'memtemp_line2',
+                self.pad_text(4, self.mem_usage(), "%") +
+                self.pad_text(5, self.cpu_load(), "%") +
+                self.pad_text(5, temp, symbol)
+            )

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -125,6 +125,7 @@ class MemTemp(plugins.Plugin):
                 v_pos = (175, 61)
 
         if self.options['orientation'] == "vertical":
+            # Dynamically create the required LabeledValue objects
             for idx, field in enumerate(self.fields):
                 v_pos_x = v_pos[0]
                 v_pos_y = v_pos[1] + ((len(self.fields) - 3) * -1 * line_spacing)

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -141,7 +141,6 @@ class MemTemp(plugins.Plugin):
                         label_spacing=self.LABEL_SPACING,
                     )
                 )
-                logging.info(f"memtemp: created '{field}'")
         else:
             # default to horizontal
             h_pos_x = h_pos[0]

--- a/pwnagotchi/plugins/default/memtemp.py
+++ b/pwnagotchi/plugins/default/memtemp.py
@@ -20,7 +20,7 @@
 # - Added CPU frequency
 # - Made field types and order configurable (max 3 fields)
 # - Made line spacing and position configurable
-# - Refactored to dynamically generate UI elements
+# - Updated code to dynamically generate UI elements
 # - Changed horizontal UI elements to Text
 # - Updated to version 1.0.2
 ###############################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

### Memtemp

**Added CPU frequency**
I believe this is useful data to have as an option. It's not enabled by default but users can configure it through settings as one of the three fields shown in the plugin (see below).

**Made field types and order configurable (max 3 fields)**
The field types and order of the fields has been made configurable through `main.plugins.memtemp.fields`. If a user prefers to use `"cpu,temp,freq"` or `"mem,freq,cpu"` then they can configure this accordingly in the settings. The `fields` config setting takes a comma separate list of field names. Whitespace is stripped in the code. Default value is `"mem,cpu,temp"`.

**Made line spacing and position configurable**
Some users might prefer to slightly tweak the position or the vertical line spacing of the UI element for their specific screen. This can now be set using `main.plugins.memtemp.position` and `main.plugins.memtemp.linespacing`, respectively. Default values are the position as is currently defined for each display, but the vertical line spacing has been reduced to 10 pixels to align with the GPS module. `position` is a comma separated string of an x and y position (white space is again stripped). `linespacing` is an integer value. Some examples (horizontal layout settings example exaggerated to show effect of `linespacing` and `position` config settings) :

![IMG_3254](https://user-images.githubusercontent.com/172588/93690157-5a688a00-fad5-11ea-9e6d-b4592420011a.jpeg)

```
main.plugins.memtemp.enabled = true
main.plugins.memtemp.scale = "celsius"
main.plugins.memtemp.orientation = "horizontal"
main.plugins.memtemp.fields = "temp,mem,freq"
main.plugins.memtemp.position = "178, 70"
main.plugins.memtemp.linespacing = 17
```

![IMG_3255](https://user-images.githubusercontent.com/172588/93690167-7f5cfd00-fad5-11ea-8ef0-ffcde26a1dab.jpeg)

```
main.plugins.memtemp.enabled = true
main.plugins.memtemp.scale = "celsius"
main.plugins.memtemp.orientation = "vertical"
main.plugins.memtemp.fields = "cpu,temp,freq"
```

**Updated the code to dynamically generate UI elements**
To support the configurable fields, position, and vertical line spacing, the UI elements are now dynamically generated as needed. If the user configures the plugin with 2 fields, then 2 `LabeledValue` objects are created (for vertical alignment). Horizontal UI elements are now `Text` objects (since they have no label anyway) and are split in a header and data UI element (of which the latter is the updated with current values).

**Changed horizontal UI elements to Text**
See the previous section.

**Updated to version 1.0.2**
Given the number of changes I felt an version bump was in order.

~### GPS~ Handled in https://github.com/evilsocket/pwnagotchi/pull/919

~There were some redundant spaces and incorrect coordinates which have now been fixed.~ 

## Motivation and Context
Fixes https://github.com/evilsocket/pwnagotchi/issues/920

- [x]  I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

Making the plugin more configurable and dynamic by adding settings for position, vertical line spacing, and field types and their order ensures that the plugin output can be configured to more user's personal tastes and requirements (some people want to know the CPU load, some want to see frequency. Some like small vertical spacing and have it align with the GPS module's output, some like a wider layout and slight shift in position).

## How Has This Been Tested?
This has been tested on a pi zero and pi 3b running 1.5.3. Default values for screen positioning have not been altered from the previous version (but individual line positioning variables have been reduced to a single horizontal and vertical coordinate as the position for each line is now automatically calculated). Vertical line spacing was reduced to 10 to align with the output of the GPS module and now configurable vs the static line spacing a `newline` character resulted in. Any incorrect position on screen for other displays than the WaveShare v2 (which has been tested), can be quickly adjusted via a configuration setting until the default is updated in the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
