### PR TITLE
Add donate option to Wigle plugin

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -52,6 +52,7 @@ main.plugins.wpa-sec.whitelist = []
 main.plugins.wigle.enabled = false
 main.plugins.wigle.api_key = ""
 main.plugins.wigle.whitelist = []
+main.plugins.wigle.donate = true
 
 main.plugins.bt-tether.enabled = false
 


### PR DESCRIPTION
## Description
Adds a new 'donate' option to allow Wigle to include data for commercial use.

Another small change: thos changes data header to reflect this is a pwnagotchi plugin, so we get credited outside 'kismet' on the [stats page](https://wigle.net/stats#androidstats).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
Fixes #928 

## How Has This Been Tested?
I don't have a test device with me, though the changes are small enough I don't foresee any issues. If you find otherwise please let me know and I will do my best to update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
