### PR TITLE
Add support for SSD1608 variant 250x122 pixel Inky pHATs

### DIFF
--- a/pwnagotchi/ui/hw/inky.py
+++ b/pwnagotchi/ui/hw/inky.py
@@ -42,6 +42,12 @@ class Inky(DisplayImpl):
             from pwnagotchi.ui.hw.libs.inkyphat.inkyphatfast import InkyPHATFast
             self._display = InkyPHATFast('black')
             self._display.set_border(InkyPHATFast.BLACK)
+        elif self.config['color'] == 'auto':
+            from inky.auto import auto
+            self._display = auto()
+            self._display.set_border(self._display.BLACK)
+            self._layout['width'] = self._display.WIDTH
+            self._layout['height'] = self._display.HEIGHT
         else:
             from inky import InkyPHAT
             self._display = InkyPHAT(self.config['color'])


### PR DESCRIPTION
## Description

This patch adds support for auto-detecting and using them when "ui.display.color" is set to "auto".

## Motivation and Context

We (that is, Pimoroni) released a set of Inky display variants which are virtually indistinguishable from their predecessors visually, but functionally incompatible due to a change of driver IC and resolution. I gave a heads up in #941.

We include an EEPROM to ID our boards. Running `python3 -m inky.eeprom` should show display variant. Variants 10, 11 and 12 are SSD1608 based. This change uses that EEPROM, plus a new "auto" choice for "ui.display.color" to support existing and perhaps even future Inky displays without the need for future modifications to pwnagotchi.

Should fix #980 and #941

## How Has This Been Tested?

This is wholly untested and thus raised as a *draft* (I'm still stuck on the end of a kitchen table in lieu of an office), but I'm hoping to walk some customers through the test process, if not soon get the time/space to do it myself.

It may also require that the "auto" colour option for Inky is documented and that a *relatively* recent Inky library is used.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
