### PR TITLE
catches wifi down exception and cycles epoch

### DIFF
--- a/bin/pwnagotchi
+++ b/bin/pwnagotchi
@@ -83,8 +83,13 @@ def do_auto_mode(agent):
                 plugins.on('internet_available', agent)
 
         except Exception as e:
-            logging.exception("main loop exception (%s)", e)
-
+            if str(e).find("wifi.interface not set") > 0:
+                logging.exception("main loop exception due to unavailable wifi device, likely programmatically disabled (%s)", e)
+                logging.info("sleeping 60 seconds then advancing to next epoch to allow for cleanup code to trigger")
+                time.sleep(60)
+                agent.next_epoch()
+            else:
+                logging.exception("main loop exception (%s)", e)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Description
It has come up in several community threads that when attempting to use the wifi adapter to connect to a network, even after pausing Bettercap, the main loop will continue to call `agent.recon()`, causing a JSON decoding exception to be thrown with no chance to recover.

This change allows the main loop to continue running, just with a pause, but by advancing to the next epoch, it triggers all the normal plugin hooks so that plugin code will have an opportunity to restart Bettercap once the wifi adapter can be freed up.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses this issue: https://github.com/evilsocket/pwnagotchi/issues/207
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested on Raspberry Pi Zero W with pwnagotchi 1.5.5. Tested with a custom plugin that manipulates the availability of the wifi adapter, then restores the Bettercap wifi recon after disconnecting wifi. This small change is all that was required to support that plugin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
