### PR TITLE
Add Display support for Waveshare 3,5" (and clones) framebuffer lcd.

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -67,6 +67,9 @@ class Display(View):
     def is_waveshare213bc(self):
         return self._implementation.name == 'waveshare213bc'
 
+    def is_waveshare35lcd(self):
+        return self._implementation.name == 'waveshare35lcd'
+
     def is_spotpear24inch(self):
         return self._implementation.name == 'spotpear24inch'
 

--- a/pwnagotchi/ui/hw/__init__.py
+++ b/pwnagotchi/ui/hw/__init__.py
@@ -12,6 +12,7 @@ from pwnagotchi.ui.hw.waveshare144lcd import Waveshare144lcd
 from pwnagotchi.ui.hw.waveshare154inch import Waveshare154inch
 from pwnagotchi.ui.hw.waveshare213d import Waveshare213d
 from pwnagotchi.ui.hw.waveshare213bc import Waveshare213bc
+from pwnagotchi.ui.hw.waveshare35lcd import Waveshare35lcd
 from pwnagotchi.ui.hw.spotpear24inch import Spotpear24inch
 
 def display_for(config):
@@ -57,6 +58,9 @@ def display_for(config):
 
     elif config['ui']['display']['type'] == 'waveshare213bc':
         return Waveshare213bc(config)
+
+    elif config['ui']['display']['type'] == 'waveshare35lcd':
+        return Waveshare35lcd(config)
 
     elif config['ui']['display']['type'] == 'spotpear24inch':
         return Spotpear24inch(config)

--- a/pwnagotchi/ui/hw/waveshare35lcd.py
+++ b/pwnagotchi/ui/hw/waveshare35lcd.py
@@ -1,0 +1,52 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+import os,time
+
+class Waveshare35lcd(DisplayImpl):
+    def __init__(self, config):
+        super(Waveshare35lcd, self).__init__(config, 'waveshare35lcd')
+        self._display = None
+
+    def layout(self):
+        fonts.setup(12, 10, 12, 70, 25, 9)
+        self._layout['width'] = 480
+        self._layout['height'] = 320
+        self._layout['face'] = (110, 60)
+        self._layout['name'] = (10, 30)
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (80, 0)
+        self._layout['uptime'] = (400, 0)
+        self._layout['line1'] = [0, 14, 480, 14]
+        self._layout['line2'] = [0,300, 480, 300]
+        self._layout['friend_face'] = (0, 220)
+        self._layout['friend_name'] = (50, 225)
+        self._layout['shakes'] = (10, 300)
+        self._layout['mode'] = (440, 300)
+        self._layout['status'] = {
+            'pos': (80, 180),
+            'font': fonts.status_font(fonts.Medium),
+            'max': 100
+        }
+
+        return self._layout
+
+    def refresh(self):
+        time.sleep(0.1)
+
+    def initialize(self):
+        from pwnagotchi.ui.hw.libs.fb import fb
+        self._display = fb
+        logging.info("initializing waveshare 3,5inch lcd display")
+        self._display.ready_fb(i=1)
+        self._display.black_scr()
+
+    def render(self, canvas):
+        self._display.show_img(canvas.rotate(0))
+        self.refresh()
+
+    def clear(self):
+        self._display.black_scr()
+        self.refresh()

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -275,6 +275,9 @@ def load_config(args):
     elif config['ui']['display']['type'] in ('ws_213bc', 'ws213bc', 'waveshare_213bc', 'waveshare213bc'):
         config['ui']['display']['type'] = 'waveshare213bc'
 
+    elif config['ui']['display']['type'] in ('waveshare35lcd'):
+        config['ui']['display']['type'] = 'waveshare35lcd'
+
     elif config['ui']['display']['type'] in ('spotpear24inch'):
         config['ui']['display']['type'] = 'spotpear24inch'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in de -->
Added config file for 3,5" Waveshare display

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with my  raspi4 (4gb) an the waveshare 3,5" display
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
