### PR TITLE
Enabled wigle to use .geo.json and .paw-gps.json files

### DIFF
--- a/pwnagotchi/plugins/default/wigle.py
+++ b/pwnagotchi/plugins/default/wigle.py
@@ -74,8 +74,6 @@ def _send_to_wigle(lines, api_key, donate=True, timeout=30):
     Uploads the file to wigle-net
     """
 
-    logging.info(lines)
-
     dummy = StringIO()
 
     for line in lines:
@@ -87,7 +85,6 @@ def _send_to_wigle(lines, api_key, donate=True, timeout=30):
                'Accept': 'application/json'}
     data = {'donate': 'on' if donate else 'false'}
     payload = {'file': dummy, 'type': 'text/csv'}
-    logging.info(dummy.getvalue())
     try:
         res = requests.post('https://api.wigle.net/api/v2/file/upload',
                             data=data,
@@ -132,7 +129,6 @@ class Wigle(plugins.Plugin):
         Called in manual mode when there's internet connectivity
         """
         if not self.ready or self.lock.locked():
-            logging.info("WIGLE: error with api key")
             return
 
         from scapy.all import Scapy_Exception

--- a/pwnagotchi/plugins/default/wigle.py
+++ b/pwnagotchi/plugins/default/wigle.py
@@ -20,8 +20,14 @@ def _extract_gps_data(path):
     """
 
     try:
-        with open(path, 'r') as json_file:
-            return json.load(json_file)
+        if path.endswith('.geo.json'):
+            with open(path, 'r') as json_file:
+                tempJson = json.load(json_file)
+                d = datetime.utcfromtimestamp(int(tempJson["ts"]))
+                return {"Latitude": tempJson["location"]["lat"], "Longitude": tempJson["location"]["lng"], "Altitude": 10, "Updated": d.strftime('%Y-%m-%dT%H:%M:%S.%f')}
+        else:
+            with open(path, 'r') as json_file:
+                return json.load(json_file)
     except OSError as os_err:
         raise os_err
     except json.JSONDecodeError as json_err:
@@ -68,6 +74,8 @@ def _send_to_wigle(lines, api_key, donate=True, timeout=30):
     Uploads the file to wigle-net
     """
 
+    logging.info(lines)
+
     dummy = StringIO()
 
     for line in lines:
@@ -79,7 +87,7 @@ def _send_to_wigle(lines, api_key, donate=True, timeout=30):
                'Accept': 'application/json'}
     data = {'donate': 'on' if donate else 'false'}
     payload = {'file': dummy, 'type': 'text/csv'}
-
+    logging.info(dummy.getvalue())
     try:
         res = requests.post('https://api.wigle.net/api/v2/file/upload',
                             data=data,
@@ -117,12 +125,14 @@ class Wigle(plugins.Plugin):
             self.options['donate'] = True
 
         self.ready = True
+        logging.info("WIGLE: ready")
 
     def on_internet_available(self, agent):
         """
         Called in manual mode when there's internet connectivity
         """
         if not self.ready or self.lock.locked():
+            logging.info("WIGLE: error with api key")
             return
 
         from scapy.all import Scapy_Exception
@@ -134,7 +144,7 @@ class Wigle(plugins.Plugin):
         all_files = os.listdir(handshake_dir)
         all_gps_files = [os.path.join(handshake_dir, filename)
                          for filename in all_files
-                         if filename.endswith('.gps.json')]
+                         if filename.endswith('.gps.json') or filename.endswith('.paw-gps.json') or filename.endswith('.geo.json')]
 
         all_gps_files = remove_whitelisted(all_gps_files, self.options['whitelist'])
         new_gps_files = set(all_gps_files) - set(reported) - set(self.skip)
@@ -143,7 +153,12 @@ class Wigle(plugins.Plugin):
             csv_entries = list()
             no_err_entries = list()
             for gps_file in new_gps_files:
-                pcap_filename = gps_file.replace('.gps.json', '.pcap')
+                if gps_file.endswith('.gps.json'):
+                    pcap_filename = gps_file.replace('.gps.json', '.pcap')
+                if gps_file.endswith('.paw-gps.json'):
+                    pcap_filename = gps_file.replace('.paw-gps.json', '.pcap')
+                if gps_file.endswith('.geo.json'):
+                    pcap_filename = gps_file.replace('.geo.json', '.pcap')
                 if not os.path.exists(pcap_filename):
                     logging.debug("WIGLE: Can't find pcap for %s", gps_file)
                     self.skip.append(gps_file)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added additional checks to if clause to allow wigle.py to take into account .geo.json and .paw-gps.json files. Paw-gps,json files are formated as .gps.json files but for .geo.json files I added additional logic to format them rightly. Geo.json files also dont have altitude value, so I hardcoded it to 10m.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was proposed by someone in the Issues so i took it upon myself to make it happen.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested on Pwnagotchi version 1.5.5 that uses RPi0W. It correctly formats and sends data to wigle.py.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
