### PR TITLE
Better ui elements for Waveshare 128x64px OLED

### DIFF
--- a/pwnagotchi/ui/hw/oledhat.py
+++ b/pwnagotchi/ui/hw/oledhat.py
@@ -10,22 +10,22 @@ class OledHat(DisplayImpl):
         self._display = None
 
     def layout(self):
-        fonts.setup(8, 8, 8, 8, 25, 9)
+        fonts.setup(8, 8, 8, 10, 10, 8)
         self._layout['width'] = 128
         self._layout['height'] = 64
-        self._layout['face'] = (0, 32)
+        self._layout['face'] = (0, 30)
         self._layout['name'] = (0, 10)
-        self._layout['channel'] = (0, 0)
-        self._layout['aps'] = (25, 0)
-        self._layout['uptime'] = (65, 0)
+        self._layout['channel'] = (72, 10)
+        self._layout['aps'] = (0, 0)
+        self._layout['uptime'] = (87, 0)
         self._layout['line1'] = [0, 9, 128, 9]
-        self._layout['line2'] = [0, 53, 128, 53]
+        self._layout['line2'] = [0, 54, 128, 54]
         self._layout['friend_face'] = (0, 41)
         self._layout['friend_name'] = (40, 43)
-        self._layout['shakes'] = (0, 53)
-        self._layout['mode'] = (103, 10)
+        self._layout['shakes'] = (0, 55)
+        self._layout['mode'] = (107, 10)
         self._layout['status'] = {
-            'pos': (30, 18),
+            'pos': (37, 19),
             'font': fonts.status_font(fonts.Small),
             'max': 18
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Better positioning of ui elements for the small Waveshare 128x64px OLED HAT display (SH1106)

## Motivation and Context
When I first tried to use the display, I thought to play with the font or its size, but I ended up just slightly rearranging the ui elements a little to avoid numerous overlaps present in the upstream version. 


## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/1002978/129464440-b0f68fe2-f9e2-4f87-9346-49d4468c2454.png)
![image](https://user-images.githubusercontent.com/1002978/129464445-7e40c4c9-5340-41a8-80e4-76c32c6bd2e1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] None of the above (better reading overall)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
