### PR TITLE
plugins/gps: add some logging around the gps off exception

### DIFF
--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -32,11 +32,13 @@ class GPS(plugins.Plugin):
             try:
                 agent.run("gps off")
             except Exception:
+                logging.info(f"bettercap gps module was already off")
                 pass
 
             agent.run(f"set gps.device {self.options['device']}")
             agent.run(f"set gps.baudrate {self.options['speed']}")
             agent.run("gps on")
+            logging.info(f"bettercap gps module enabled on {self.options['device']}")
             self.running = True
         else:
             logging.warning("no GPS detected")


### PR DESCRIPTION
This is a very nit-pick pull request, but it could save some headaches from people trying to debug GPS errors.

## Description
When using a GPS module, `/var/log/pwnagotchi.log` shows the following entries:
```
[2021-10-19 10:34:24,998] [INFO] enabling bettercap's gps module for /dev/ttyAMA0
[2021-10-19 10:34:25,311] [INFO] error 400: module gps is not running
[2021-10-19 10:35:07,271] [INFO] sending association frame to TP-Link_2334...
```
that `error 400 module GPS is not running` comes from a handled exception inside the `on_ready` function and it's a little bit weird at a first glance if you're trying to debug the GPS connection/lock-up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

closes #1041

## How Has This Been Tested?
I've just built a new image on a Raspberry PI Zero W.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
