### PR TITLE
Adds back ups_lite plugin defaults to default.toml

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -85,6 +85,9 @@ main.plugins.memtemp.orientation = "horizontal"
 main.plugins.paw-gps.enabled = false
 main.plugins.paw-gps.ip = ""
 
+main.plugins.ups_lite.enabled = false
+main.plugins.ups_lite.shutdown = 2
+
 main.plugins.gpio_buttons.enabled = false
 
 main.plugins.led.enabled = true


### PR DESCRIPTION
Adds back defaults for the ups_lite plugin that currently are not present in the default.toml

## Description
The default.toml currently does not have the required settings for the ups_lite plugin. This will throw the following error if the plugin is enabled and no additional changes are made to the config.toml.

```
Unhandled exception in thread started by <function locked_cb at 0xb651b270>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/pwnagotchi/plugins/__init__.py", line 85, in locked_cb
    cb(*args, *kwargs)
  File "/usr/local/lib/python3.7/dist-packages/pwnagotchi/plugins/default/ups_lite.py", line 83, in on_ui_update
    if capacity <= self.options['shutdown']:
KeyError: 'shutdown'
```

## Motivation and Context

Plugin should 'just' work using default settings after enabling and not require troubleshooting/inspecting logs.

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md)) 

https://github.com/evilsocket/pwnagotchi/issues/1051


## How Has This Been Tested?

Added `main.plugins.ups_lite.enabled = false` and `main.plugins.ups_lite.shutdown = 2` to config.toml.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
