### PR TITLE
Ensure wpa_supplicant logs to syslog

### DIFF
--- a/builder/data/usr/bin/pwnlib
+++ b/builder/data/usr/bin/pwnlib
@@ -158,7 +158,7 @@ network={
     frequency=2437
 }
 EOF
-        >/dev/null 2>&1 wpa_supplicant -D nl80211 -i wlan0 -c /tmp/wpa_supplicant.conf &
+        >/dev/null 2>&1 wpa_supplicant -u -s -O -D nl80211 -i wlan0 -c /tmp/wpa_supplicant.conf &
       fi
 
       if ! pgrep dnsmasq >/dev/null 2>&1; then


### PR DESCRIPTION
Ensure wpa_supplicant logs to syslog

## Description
After enabling encryption as described in the documentation I noticed that every so often the `DECRYPT_ME` hotspot is not started. 

## Motivation and Context
Currently wpa_supplicant does not log to its own file or syslog so this issue is hard to pin down. Having wpa_supplicant log to syslog allows for some troubleshooting

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

https://github.com/evilsocket/pwnagotchi/issues/1055

## How Has This Been Tested?

Manually updated wpa_supplicant command in pwnlib with additional flags (`-u -s -O`) and rebooted. wpa_supplicant now logs to syslog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
