### PR TITLE
resolve issue #1057

### DIFF
--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -138,6 +138,16 @@
       repo: deb http://http.re4son-kernel.com/re4son/ kali-pi main
       state: present
 
+  - name: create /etc/apt/preferences.d/kali.pref
+    copy:
+      dest: /etc/apt/preferences.d/kali.pref
+      force: yes
+      content: |
+        # ensure kali packages that are installed take precedence
+        Package: *
+        Pin: release n=kali-pi
+        Pin-Priority: 999
+
   - name: add firmware packages to hold
     dpkg_selections:
       name: "{{ item }}"


### PR DESCRIPTION
this provides an ansible configuration stanza to create the kali.pref
which will prefer bootloader/kernel/libraspberrypi0 from  kali instead of debian

## Description
Creates  /etc/apt/preferences.d/kali.pref
pins the packages for the kali-pi repository to be preferred over non-kali-pi repos

## Motivation and Context

This resolves issues with system updates and bootloader/kernel/libraspberrypi0 dependencies.

Without this change, the generic repo would overwrite the kernel and bootloader, as well as libraspberrypi packages,
which breaks the functionality of pwnagotchi.

With this change,  'apt full-upgrade'  works as expected, and does not break the system.

- [X ] I have raised an issue to propose this change (  #1057 )


## How Has This Been Tested?
Tested manually.   

Also tested using the script https://github.com/isthisausername2/pwnagotchi_rpi_zero_2_fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
