### PR TITLE
delete old log after rotation

### DIFF
--- a/pwnagotchi/log.py
+++ b/pwnagotchi/log.py
@@ -307,3 +307,5 @@ def do_rotate(filename, stats, cfg):
     with open(log_filename, 'rb') as src:
         with gzip.open(archive_filename, 'wb') as dst:
             dst.writelines(src)
+
+    os.remove(log_filename)


### PR DESCRIPTION
This commit deletes the original moved logfile after compression.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
os.remove at the end of log rotation

## Motivation and Context

The current rotation keeps the logfiles which quickly fills up any
zram compressed log mounts which will cause the pwnagotchi to hang.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1047 
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- added line to log.py
- artificially filled pwnagotchi.log above threshold
- restarted to initiate rotation
- pwnagotchi-XX.gz exists, uncompressed log missing
<!--- Include details of your testing environment, and the tests you ran to -->
1.5.5 updated
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
