### PR TITLE
Add support for Pi Zero 2W

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,17 @@ install:
 	curl https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_linux_amd64.zip -o /tmp/packer.zip
 	unzip /tmp/packer.zip -d /tmp
 	sudo mv /tmp/packer /usr/bin/packer
-	git clone https://github.com/solo-io/packer-builder-arm-image /tmp/packer-builder-arm-image
-	cd /tmp/packer-builder-arm-image && go get -d ./... && go build
-	sudo cp /tmp/packer-builder-arm-image/packer-builder-arm-image /usr/bin
+	git clone https://github.com/solo-io/packer-plugin-arm-image /tmp/packer-plugin-arm-image
+	cd /tmp/packer-plugin-arm-image && go get -d ./... && go build
+	sudo cp /tmp/packer-plugin-arm-image/packer-plugin-arm-image /usr/bin
 
 image:
 	cd builder && sudo /usr/bin/packer build -var "pwn_hostname=$(PWN_HOSTNAME)" -var "pwn_version=$(PWN_VERSION)" pwnagotchi.json
-	sudo mv builder/output-pwnagotchi/image pwnagotchi-raspbian-lite-$(PWN_VERSION).img
-	sudo sha256sum pwnagotchi-raspbian-lite-$(PWN_VERSION).img > pwnagotchi-raspbian-lite-$(PWN_VERSION).sha256
-	sudo zip pwnagotchi-raspbian-lite-$(PWN_VERSION).zip pwnagotchi-raspbian-lite-$(PWN_VERSION).sha256 pwnagotchi-raspbian-lite-$(PWN_VERSION).img
+	sudo mv builder/output-pwnagotchi/image pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).img
+	sudo sha256sum pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).img > pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).sha256
+	sudo zip pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).zip pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).sha256 pwnagotchi-raspberrypi-os-lite-$(PWN_VERSION).img
 
 clean:
 	rm -rf /tmp/packer-builder-arm-image
-	rm -f pwnagotchi-raspbian-lite-*.zip pwnagotchi-raspbian-lite-*.img pwnagotchi-raspbian-lite-*.sha256
+	rm -f pwnagotchi-raspberrypi-os-lite-*.zip pwnagotchi-raspberrypi-os-lite-*.img pwnagotchi-raspberrypi-os-lite-*.sha256
 	rm -rf builder/output-pwnagotchi  builder/packer_cache

--- a/builder/data/usr/bin/pwnlib
+++ b/builder/data/usr/bin/pwnlib
@@ -33,6 +33,7 @@ reload_brcm() {
 
 # starts mon0
 start_monitor_interface() {
+  rfkill unblock all
   ifconfig wlan0 up && iw phy "$(iw phy | head -1 | cut -d" " -f2)" interface add mon0 type monitor && ifconfig mon0 up
 }
 

--- a/builder/data/usr/bin/pwnlib
+++ b/builder/data/usr/bin/pwnlib
@@ -33,7 +33,7 @@ reload_brcm() {
 
 # starts mon0
 start_monitor_interface() {
-  iw phy "$(iw phy | head -1 | cut -d" " -f2)" interface add mon0 type monitor && ifconfig mon0 up
+  ifconfig wlan0 up && iw phy "$(iw phy | head -1 | cut -d" " -f2)" interface add mon0 type monitor && ifconfig mon0 up
 }
 
 # stops mon0

--- a/builder/pwnagotchi.json
+++ b/builder/pwnagotchi.json
@@ -3,8 +3,8 @@
     {
       "name": "pwnagotchi",
       "type": "arm-image",
-      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-07-12/2019-07-10-raspbian-buster-lite.zip",
-      "iso_checksum": "9e5cf24ce483bb96e7736ea75ca422e3560e7b455eee63dd28f66fa1825db70e",
+      "iso_url": "https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2022-04-07/2022-04-04-raspios-buster-armhf-lite.img.xz",
+      "iso_checksum": "42fd907a0da36b8a8ce9db9cd1cb77746b6a10c4b77f8d0ae0b8065a3b358a37",
       "last_partition_extra_size": 3221225472
     }
   ],

--- a/builder/pwnagotchi.yml
+++ b/builder/pwnagotchi.yml
@@ -53,6 +53,10 @@
           - triggerhappy
           - wpa_supplicant
           - nfs-common
+          - libraspberrypi0
+          - libraspberrypi-dev
+          - libraspberrypi-doc
+          - libraspberrypi-bin
         install:
           - rsync
           - vim

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ smbus2==0.3.0
 Pillow==5.4.1
 spidev==3.4
 gast==0.2.2
+itsdangerous==1.1.0
+markupsafe==1.1.1
+Werkzeug==0.14.1
 flask==1.0.2
 flask-cors==3.0.7
 flask-wtf==0.14.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch uses a newer base image and kalipi kernel in order to support newer Pi revisions, like Zero 2W

## Motivation and Context
As pointed out in #1046, it would be nice to support the new Zero 2W.


## How Has This Been Tested?
This patch has been crowd-tested since I don't have the resources to test all the possible configurations and scenarios.
Since I ported nexmon to 2W I distributed unofficial images (on #1046 and /r/pwnagotchi) to let people test them and report bugs. 
Since I didn't touch the pwnagotchi code itself I wasn't expecting major issues, but wanted to be sure new distro/kernel/firmware weren't introducing regressions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
