### PR TITLE
Fix pwnagotchi crash when updating hostname

### DIFF
--- a/pwnagotchi/__init__.py
+++ b/pwnagotchi/__init__.py
@@ -41,7 +41,7 @@ def set_name(new_name):
             fp.write(patched)
 
         os.system("hostname '%s'" % new_name)
-        pwnagotchi.reboot()
+        reboot()
 
 
 def name():


### PR DESCRIPTION
Fixes #1096 (closed by the person who opened it but it was never actually fixed)

## Description
The pwnagotchi process crashes when calling `pwnagotchi.reboot` because `pwnagotchi` was never imported.  Importing it is actually unnecessary as the `reboot` function is defined in the same source file.

## Motivation and Context
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Manually made this code change on my pwnagotchi and updated the hostname a few times.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
