### PR TITLE
Update GPS plugin to allow connecting to GPSD

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -33,7 +33,7 @@ main.plugins.net-pos.api_key = "test"
 
 main.plugins.gps.enabled = false
 main.plugins.gps.speed = 19200
-main.plugins.gps.device = "/dev/ttyUSB0"
+main.plugins.gps.device = "/dev/ttyUSB0" # for GPSD: "localhost:2947"
 
 main.plugins.webgpsmap.enabled = false
 

--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -25,7 +25,7 @@ class GPS(plugins.Plugin):
         logging.info(f"gps plugin loaded for {self.options['device']}")
 
     def on_ready(self, agent):
-        if os.path.exists(self.options["device"]):
+        if os.path.exists(self.options["device"]) or ":" in self.options["device"]:
             logging.info(
                 f"enabling bettercap's gps module for {self.options['device']}"
             )


### PR DESCRIPTION
Fixes #1122

Bettercap supports connecting to a GPSD server with hostname:port since v2.29.  
This allows users to use GPSD/chrony to set the system clock while still being able to use the GPS plugin.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I had to make this change on my personal pwnagotchi in order for it to use GPSD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
