### PR TITLE
feat: Update Web UI so it's accessible on both ipv4 and ipv6

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -192,7 +192,7 @@ ui.faces.upload1 = "(1__1)"
 ui.faces.upload2 = "(0__1)"
 
 ui.web.enabled = true
-ui.web.address = "0.0.0.0"
+ui.web.address = "::" # listening on both ipv4 and ipv6 - switch to 0.0.0.0 to listen on just ipv4
 ui.web.username = "changeme"
 ui.web.password = "changeme"
 ui.web.origin = ""

--- a/pwnagotchi/ui/web/server.py
+++ b/pwnagotchi/ui/web/server.py
@@ -44,7 +44,8 @@ class Server:
             CSRFProtect(app)
             Handler(self._config, self._agent, app)
 
-            logging.info("web ui available at http://%s:%d/" % (self._address, self._port))
+            formatServerIpAddress = '[::]' if self._address == '::' else self._address;
+            logging.info("web ui available at http://%s:%d/" % (formatServerIpAddress, self._port))
 
             app.run(host=self._address, port=self._port, debug=False)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tweak default config file so it bootstraps the Web UI server to both ipv6 and ipv4 by default. I also left a comment in there explaining how to revert to only loading the server on an ipv4 address by replacing the address with `0.0.0.0`. I also updated the `server.py` file so it formats the ipv6 url in a more user friendly manner

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

I didn't raise the issue but an enhancement request was put in so this addresses and closes [#915 ](https://github.com/evilsocket/pwnagotchi/issues/915)

FIXES #915 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it for several hours locally tethering my pwnagotchi to my laptop and desktop via usb, bluetooth, and a USB Wi-Fi dongle that I had laying around. Everything worked as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

For the documentation I left comments in the default `config.toml` file that explains the fix. It's really pretty basic. Instead of loading the web UI on `0.0.0.0` we instead load it on the ipv6 equivalent `::` and in turn ipv6 routes traffic back to ipv4