### PR TITLE
fix: make sure to run fonts.init() so preview.py works

### DIFF
--- a/pwnagotchi/ui/hw/base.py
+++ b/pwnagotchi/ui/hw/base.py
@@ -3,6 +3,8 @@ import pwnagotchi.ui.fonts as fonts
 
 class DisplayImpl(object):
     def __init__(self, config, name):
+        if fonts.Medium is None:
+            fonts.init(config)
         self.name = name
         self.config = config['ui']['display']
         self._layout = {

--- a/scripts/preview.py
+++ b/scripts/preview.py
@@ -101,6 +101,10 @@ def main():
     main:
         lang: {lang}
     ui:
+        font:
+            name: 'DejaVuSansMono'
+            size_offset: 0
+            size: 0
         fps: 0.3
         display:
             enabled: false
@@ -110,9 +114,8 @@ def main():
             type: {display}
             web:
                 enabled: true
-                address: "0.0.0.0"
+                address: '::'
                 port: 8080
-
         faces:
             look_r: '( ⚆_⚆)'
             look_l: '(☉_☉ )'


### PR DESCRIPTION
Signed-off-by: Rocco Augusto <therocco@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
While trying to run the `scripts/preview.py` script to locally test some template modifications I was making for myself I discovered it was erroring out due to an `AttributeError: NoneType` in `pwnagotchi/ui/fonts.py` on line 27

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

I wanted to play around with the `preview.py` script and could not do so in it's current state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have generated many screen demos testing it once it was fixed as seen in the attached images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

`fonts.init()` was never being called in the `preview.py` script so variables that the font module relied on were all `NoneType`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

No documentation change is required since now the script is working as it is supposed to from the documentation I saw prior.

![waveshare213inb_v4](https://user-images.githubusercontent.com/801056/213882771-42447d5c-c77a-4be4-bca4-00424bb085eb.png)

![waveshare_v2](https://user-images.githubusercontent.com/801056/213882774-f5959224-28e9-45ba-ac8a-427c069a9a8c.png)

![ws1-ws2-ws2v4](https://user-images.githubusercontent.com/801056/213882775-056db2b9-d7a3-48e9-8ef7-cb98b09c4b18.png)
