### PR TITLE
give plugins access to all raw bettercap events

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -324,6 +324,12 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
         found_handshake = False
         jmsg = json.loads(msg)
 
+        # give plugins access to all raw bettercap events
+        try:
+            plugins.on('bcap_%s' % re.sub(r"[^a-z0-9_]+", "_",  jmsg['tag'].lower()), self, jmsg)
+        except Exception as err:
+            logging.error("Processing event: %s" % err)
+
         if jmsg['tag'] == 'wifi.client.handshake':
             filename = jmsg['data']['file']
             sta_mac = jmsg['data']['station']


### PR DESCRIPTION
Modified agent.py. to call "plugins.on" for all bettercap events

## Description
Pass all bettercap events to plugins

## Motivation and Context
This gives plugins more access to events, allowing plugins to respond to new BLE and HID devices, get gps updates,
and more. I have used this to develop BLE monitor plugin.

## How Has This Been Tested?
I tested the changes with the ble_monitor plugin and others. I have been running this code on my pwnagotchi for months.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
