### PR TITLE
allow session() to fetch just a section of info

### DIFF
--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -31,8 +31,10 @@ class Client(object):
         self.websocket = "ws://%s:%s@%s:%d/api" % (username, password, hostname, port)
         self.auth = HTTPBasicAuth(username, password)
 
-    def session(self):
-        r = requests.get("%s/session" % self.url, auth=self.auth)
+    # session takes optional argument to pull a sub-dictionary
+    #  ex.: "session/wifi", "session/ble"
+    def session(self, sess="session"):
+        r = requests.get("%s/%s" % (self.url, sess), auth=self.auth)
         return decode(r)
 
     async def start_websocket(self, consumer):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow session() to request a subsection of info from bettercap
## Description
<!--- Describe your changes in detail -->
bettercap.session() takes an optional parameter to request just a part of the tree.  The default behavior requests "session", which gets everything.  The parameter can be set as "session/wifi" or "session/ble", etc to get just that part of the tree. "session/gps" does not seem to be supported by bettercap, but session/wifi, session/ble and session/hid are.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Change required to reduce the data going back and forth in some cases.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/evilsocket/pwnagotchi/issues/1193
- [X ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running on pwnagotchi for months.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ X] I have signed-off my commits with `git commit -s`
